### PR TITLE
Adding quilt package so that we can use quilt for package management

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.0-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    quilt \ 
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.1-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    quilt \ 
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/data/php-cli/Dockerfile
+++ b/data/php-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:{%version%}-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    quilt \ 
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 


### PR DESCRIPTION
Adding quilt package so that we can use quilt for package management (which is great because git applier is broken in my docker environments)

Note: This pull request is related to https://github.com/magento/ece-tools/pull/226