### PR TITLE
Adding quilt so that we can use docker containers with ece-tools from a git worktree

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.0-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    quilt \ 
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.1-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    quilt \ 
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/data/php-cli/Dockerfile
+++ b/data/php-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:{%version%}-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    quilt \ 
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 


### PR DESCRIPTION
Note:  To benefit from this, we also need https://github.com/magento/ece-tools/pull/226