### PR TITLE
Enabling pcntl for php cli images.

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -28,10 +28,10 @@ RUN docker-php-ext-install \
   intl \
   mbstring \
   mcrypt \
+  pcntl \
   pdo_mysql \
   xsl \
   zip \
-  pcntl \
   bcmath \
   soap \
   sockets

--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -31,6 +31,7 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
+  pcntl \
   bcmath \
   soap \
   sockets

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -28,10 +28,10 @@ RUN docker-php-ext-install \
   intl \
   mbstring \
   mcrypt \
+  pcntl \
   pdo_mysql \
   xsl \
   zip \
-  pcntl \
   bcmath \
   soap \
   sockets

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -31,6 +31,7 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
+  pcntl \
   bcmath \
   soap \
   sockets

--- a/data/php-cli/Dockerfile
+++ b/data/php-cli/Dockerfile
@@ -28,6 +28,7 @@ RUN docker-php-ext-install \
   intl \
   mbstring \
   mcrypt \
+  pcntl \
   pdo_mysql \
   xsl \
   zip \


### PR DESCRIPTION
The pcntl extension is used by the magento cli tools (when extension is enabled).  Because this PHP extension (which comes with stock PHP) is enabled on our cloud platform, we should also enable it in our docker for better testing and development.