### PR TITLE
MAGECLOUD-2477 Fixing docker issues for GNU/Linux hosts.

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.0-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    acl \
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -28,10 +28,10 @@ RUN docker-php-ext-install \
   intl \
   mbstring \
   mcrypt \
+  pcntl \
   pdo_mysql \
   xsl \
   zip \
-  pcntl \
   bcmath \
   soap \
   sockets

--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -31,6 +31,7 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
+  pcntl \
   bcmath \
   soap \
   sockets

--- a/7.0-cli/bin/magento-installer
+++ b/7.0-cli/bin/magento-installer
@@ -6,12 +6,19 @@ set -e
 
 MAGENTO_COMMAND="magento-command"
 ECE_COMMAND="ece-command"
+COMPOSER_CACHE_DIRECTORY=/root/.composer/cache
 
 composer --working-dir=$MAGENTO_ROOT install
 
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT
@@ -39,9 +46,16 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
+
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/7.0-cli/bin/magento-installer
+++ b/7.0-cli/bin/magento-installer
@@ -9,7 +9,6 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-#chown -R www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
@@ -35,7 +34,6 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-#chown -R www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/7.0-cli/bin/magento-installer
+++ b/7.0-cli/bin/magento-installer
@@ -9,7 +9,9 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-chown -R www-data:www-data $MAGENTO_ROOT
+#chown -R www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 if [ "$M2SETUP_USE_SAMPLE_DATA" = "true" ]; then
   echo "Deploying Sample Data..."
@@ -33,6 +35,8 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-chown -R www-data:www-data $MAGENTO_ROOT
+#chown -R www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 echo "Installation complete"

--- a/7.0-cli/bin/magento-installer
+++ b/7.0-cli/bin/magento-installer
@@ -9,8 +9,13 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 if [ "$M2SETUP_USE_SAMPLE_DATA" = "true" ]; then
   echo "Deploying Sample Data..."
@@ -34,7 +39,12 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 echo "Installation complete"

--- a/7.0-cli/docker-entrypoint.sh
+++ b/7.0-cli/docker-entrypoint.sh
@@ -4,7 +4,9 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-chown www-data:www-data $MAGENTO_ROOT
+#chown www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.0-cli/docker-entrypoint.sh
+++ b/7.0-cli/docker-entrypoint.sh
@@ -4,7 +4,6 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-#chown www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/7.0-cli/docker-entrypoint.sh
+++ b/7.0-cli/docker-entrypoint.sh
@@ -4,8 +4,13 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.0-cli/docker-entrypoint.sh
+++ b/7.0-cli/docker-entrypoint.sh
@@ -4,9 +4,18 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
+
+COMPOSER_CACHE_DIRECTORY=/root/.composer/cache
+
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/7.0-fpm/Dockerfile
+++ b/7.0-fpm/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.0-fpm
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    acl \ 
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/7.0-fpm/Dockerfile
+++ b/7.0-fpm/Dockerfile
@@ -3,7 +3,7 @@ FROM php:7.0-fpm
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
-    acl \ 
+    acl \
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/7.0-fpm/docker-entrypoint.sh
+++ b/7.0-fpm/docker-entrypoint.sh
@@ -4,7 +4,9 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-chown www-data:www-data $MAGENTO_ROOT
+#chown www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.0-fpm/docker-entrypoint.sh
+++ b/7.0-fpm/docker-entrypoint.sh
@@ -7,6 +7,9 @@ mkdir -p $MAGENTO_ROOT
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/7.0-fpm/docker-entrypoint.sh
+++ b/7.0-fpm/docker-entrypoint.sh
@@ -4,7 +4,6 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-#chown www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/7.0-fpm/docker-entrypoint.sh
+++ b/7.0-fpm/docker-entrypoint.sh
@@ -4,8 +4,13 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -28,10 +28,10 @@ RUN docker-php-ext-install \
   intl \
   mbstring \
   mcrypt \
+  pcntl \
   pdo_mysql \
   xsl \
   zip \
-  pcntl \
   bcmath \
   soap \
   sockets

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.1-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    acl \
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -31,6 +31,7 @@ RUN docker-php-ext-install \
   pdo_mysql \
   xsl \
   zip \
+  pcntl \
   bcmath \
   soap \
   sockets

--- a/7.1-cli/bin/magento-installer
+++ b/7.1-cli/bin/magento-installer
@@ -6,12 +6,19 @@ set -e
 
 MAGENTO_COMMAND="magento-command"
 ECE_COMMAND="ece-command"
+COMPOSER_CACHE_DIRECTORY=/root/.composer/cache
 
 composer --working-dir=$MAGENTO_ROOT install
 
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT
@@ -39,9 +46,16 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
+
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/7.1-cli/bin/magento-installer
+++ b/7.1-cli/bin/magento-installer
@@ -9,7 +9,6 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-#chown -R www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
@@ -35,7 +34,6 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-#chown -R www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/7.1-cli/bin/magento-installer
+++ b/7.1-cli/bin/magento-installer
@@ -9,7 +9,9 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-chown -R www-data:www-data $MAGENTO_ROOT
+#chown -R www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 if [ "$M2SETUP_USE_SAMPLE_DATA" = "true" ]; then
   echo "Deploying Sample Data..."
@@ -33,6 +35,8 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-chown -R www-data:www-data $MAGENTO_ROOT
+#chown -R www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 echo "Installation complete"

--- a/7.1-cli/bin/magento-installer
+++ b/7.1-cli/bin/magento-installer
@@ -9,8 +9,13 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 if [ "$M2SETUP_USE_SAMPLE_DATA" = "true" ]; then
   echo "Deploying Sample Data..."
@@ -34,7 +39,12 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 echo "Installation complete"

--- a/7.1-cli/docker-entrypoint.sh
+++ b/7.1-cli/docker-entrypoint.sh
@@ -4,7 +4,9 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-chown www-data:www-data $MAGENTO_ROOT
+#chown www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.1-cli/docker-entrypoint.sh
+++ b/7.1-cli/docker-entrypoint.sh
@@ -4,7 +4,6 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-#chown www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/7.1-cli/docker-entrypoint.sh
+++ b/7.1-cli/docker-entrypoint.sh
@@ -4,8 +4,13 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.1-cli/docker-entrypoint.sh
+++ b/7.1-cli/docker-entrypoint.sh
@@ -4,9 +4,18 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
+
+COMPOSER_CACHE_DIRECTORY=/root/.composer/cache
+
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/7.1-fpm/Dockerfile
+++ b/7.1-fpm/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.1-fpm
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    acl \
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/7.1-fpm/docker-entrypoint.sh
+++ b/7.1-fpm/docker-entrypoint.sh
@@ -4,7 +4,9 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-chown www-data:www-data $MAGENTO_ROOT
+#chown www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.1-fpm/docker-entrypoint.sh
+++ b/7.1-fpm/docker-entrypoint.sh
@@ -7,6 +7,9 @@ mkdir -p $MAGENTO_ROOT
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/7.1-fpm/docker-entrypoint.sh
+++ b/7.1-fpm/docker-entrypoint.sh
@@ -4,7 +4,6 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-#chown www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/7.1-fpm/docker-entrypoint.sh
+++ b/7.1-fpm/docker-entrypoint.sh
@@ -4,8 +4,13 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/data/php-cli/Dockerfile
+++ b/data/php-cli/Dockerfile
@@ -28,6 +28,7 @@ RUN docker-php-ext-install \
   intl \
   mbstring \
   mcrypt \
+  pcntl \
   pdo_mysql \
   xsl \
   zip \

--- a/data/php-cli/Dockerfile
+++ b/data/php-cli/Dockerfile
@@ -3,6 +3,7 @@ FROM php:{%version%}-cli
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    acl \
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/data/php-cli/bin/magento-installer
+++ b/data/php-cli/bin/magento-installer
@@ -6,12 +6,19 @@ set -e
 
 MAGENTO_COMMAND="magento-command"
 ECE_COMMAND="ece-command"
+COMPOSER_CACHE_DIRECTORY=/root/.composer/cache
 
 composer --working-dir=$MAGENTO_ROOT install
 
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT
@@ -39,9 +46,16 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
+
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/data/php-cli/bin/magento-installer
+++ b/data/php-cli/bin/magento-installer
@@ -9,7 +9,6 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-#chown -R www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
@@ -35,7 +34,6 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-#chown -R www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/data/php-cli/bin/magento-installer
+++ b/data/php-cli/bin/magento-installer
@@ -9,7 +9,9 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-chown -R www-data:www-data $MAGENTO_ROOT
+#chown -R www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 if [ "$M2SETUP_USE_SAMPLE_DATA" = "true" ]; then
   echo "Deploying Sample Data..."
@@ -33,6 +35,8 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-chown -R www-data:www-data $MAGENTO_ROOT
+#chown -R www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 echo "Installation complete"

--- a/data/php-cli/bin/magento-installer
+++ b/data/php-cli/bin/magento-installer
@@ -9,8 +9,13 @@ ECE_COMMAND="ece-command"
 
 composer --working-dir=$MAGENTO_ROOT install
 
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 if [ "$M2SETUP_USE_SAMPLE_DATA" = "true" ]; then
   echo "Deploying Sample Data..."
@@ -34,7 +39,12 @@ echo "Fixing file permissions.."
 find $MAGENTO_ROOT/pub -type f -exec chmod 664 {} \;
 find $MAGENTO_ROOT/pub -type d -exec chmod 775 {} \;
 
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 echo "Installation complete"

--- a/data/php-cli/docker-entrypoint.sh
+++ b/data/php-cli/docker-entrypoint.sh
@@ -4,7 +4,9 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-chown www-data:www-data $MAGENTO_ROOT
+#chown www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/data/php-cli/docker-entrypoint.sh
+++ b/data/php-cli/docker-entrypoint.sh
@@ -4,7 +4,6 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-#chown www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/data/php-cli/docker-entrypoint.sh
+++ b/data/php-cli/docker-entrypoint.sh
@@ -4,8 +4,13 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/data/php-cli/docker-entrypoint.sh
+++ b/data/php-cli/docker-entrypoint.sh
@@ -4,9 +4,18 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
+
+COMPOSER_CACHE_DIRECTORY=/root/.composer/cache
+
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     COMPOSER_CACHE_OWNER=$(ls -ld $COMPOSER_CACHE_DIRECTORY | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -d -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
+     setfacl -R -m "u:${COMPOSER_CACHE_OWNER}:7" $COMPOSER_CACHE_DIRECTORY
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/data/php-fpm/Dockerfile
+++ b/data/php-fpm/Dockerfile
@@ -3,6 +3,7 @@ FROM php:{%version%}-fpm
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
+    acl \
     libfreetype6-dev \ 
     libicu-dev \ 
     libjpeg62-turbo-dev \ 

--- a/data/php-fpm/docker-entrypoint.sh
+++ b/data/php-fpm/docker-entrypoint.sh
@@ -4,7 +4,9 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-chown www-data:www-data $MAGENTO_ROOT
+#chown www-data:www-data $MAGENTO_ROOT
+setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
+setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/data/php-fpm/docker-entrypoint.sh
+++ b/data/php-fpm/docker-entrypoint.sh
@@ -7,6 +7,9 @@ mkdir -p $MAGENTO_ROOT
 if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 then 
      echo "Adding permissions for www-data group via setfacl"
+     MAGENTO_ROOT_OWNER=$(ls -ld $MAGENTO_ROOT | awk '{print $3}')
+     setfacl -R -d -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
+     setfacl -R -m "u:${MAGENTO_ROOT_OWNER}:7" $MAGENTO_ROOT
 else 
      echo "Changing permissions to www-data user and group via chown"
      chown -R www-data:www-data $MAGENTO_ROOT

--- a/data/php-fpm/docker-entrypoint.sh
+++ b/data/php-fpm/docker-entrypoint.sh
@@ -4,7 +4,6 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-#chown www-data:www-data $MAGENTO_ROOT
 setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
 setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
 

--- a/data/php-fpm/docker-entrypoint.sh
+++ b/data/php-fpm/docker-entrypoint.sh
@@ -4,8 +4,13 @@
 
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
-setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT
-setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+if setfacl -R -d -m "g:www-data:7" $MAGENTO_ROOT && setfacl -R -m "g:www-data:7" $MAGENTO_ROOT
+then 
+     echo "Adding permissions for www-data group via setfacl"
+else 
+     echo "Changing permissions to www-data user and group via chown"
+     chown -R www-data:www-data $MAGENTO_ROOT
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then


### PR DESCRIPTION
Note:  Still not quit done with this.   There is a few more things that need fixing.

https://magento2.atlassian.net/browse/MAGECLOUD-2477

Fixing the file permissions problem.

I found a simpler solution to solving the file permission problem that only makes minor changes.  Instead of doing any fancy userid remapping or changing the userid of the docker containers, instead we do something simpler:
Use ACL to add www-data _instead_ of using chown to change the only permissions to www-data.
This way, we can keep editing files locally on the host system, while at the same time being able to run Magento inside of the docker containers.