### PR TITLE
Use COPY instead of ADD in Dockerfile

### DIFF
--- a/7.0-cli/Dockerfile
+++ b/7.0-cli/Dockerfile
@@ -34,10 +34,10 @@ ENV MAGENTO_ROOT /var/www/magento
 ENV DEBUG false
 ENV M2_SAMPLE_DATA false
 
-ADD etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
-ADD etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
+COPY etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
+COPY etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
 
-ADD docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
@@ -47,12 +47,12 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 
 VOLUME /root/.composer/cache
 
-ADD etc/php-cli.ini /usr/local/etc/php/conf.d/zz-magento.ini
+COPY etc/php-cli.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-ADD bin/* /usr/local/bin/
+COPY bin/* /usr/local/bin/
 
 RUN ["chmod", "+x", "/usr/local/bin/magento-installer"]
 RUN ["chmod", "+x", "/usr/local/bin/magento-command"]

--- a/7.1-cli/Dockerfile
+++ b/7.1-cli/Dockerfile
@@ -34,10 +34,10 @@ ENV MAGENTO_ROOT /var/www/magento
 ENV DEBUG false
 ENV M2_SAMPLE_DATA false
 
-ADD etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
-ADD etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
+COPY etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
+COPY etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
 
-ADD docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
@@ -47,12 +47,12 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 
 VOLUME /root/.composer/cache
 
-ADD etc/php-cli.ini /usr/local/etc/php/conf.d/zz-magento.ini
+COPY etc/php-cli.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-ADD bin/* /usr/local/bin/
+COPY bin/* /usr/local/bin/
 
 RUN ["chmod", "+x", "/usr/local/bin/magento-installer"]
 RUN ["chmod", "+x", "/usr/local/bin/magento-command"]

--- a/7.1-fpm/Dockerfile
+++ b/7.1-fpm/Dockerfile
@@ -28,10 +28,10 @@ ENV MAGENTO_ROOT /var/www/magento
 
 ENV DEBUG false
 
-ADD etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
-ADD etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
+COPY etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
+COPY etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
 
-ADD docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
@@ -40,7 +40,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
 
-ADD etc/php-fpm.ini /usr/local/etc/php/conf.d/zz-magento.ini
-ADD etc/php-fpm.conf /usr/local/etc/
+COPY etc/php-fpm.ini /usr/local/etc/php/conf.d/zz-magento.ini
+COPY etc/php-fpm.conf /usr/local/etc/
 
 CMD ["php-fpm", "-R"]

--- a/7.2-cli/Dockerfile
+++ b/7.2-cli/Dockerfile
@@ -34,10 +34,10 @@ ENV MAGENTO_ROOT /var/www/magento
 ENV DEBUG false
 ENV M2_SAMPLE_DATA false
 
-ADD etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
-ADD etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
+COPY etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
+COPY etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
 
-ADD docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
@@ -47,12 +47,12 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 
 VOLUME /root/.composer/cache
 
-ADD etc/php-cli.ini /usr/local/etc/php/conf.d/zz-magento.ini
+COPY etc/php-cli.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-ADD bin/* /usr/local/bin/
+COPY bin/* /usr/local/bin/
 
 RUN ["chmod", "+x", "/usr/local/bin/magento-installer"]
 RUN ["chmod", "+x", "/usr/local/bin/magento-command"]

--- a/7.2-fpm/Dockerfile
+++ b/7.2-fpm/Dockerfile
@@ -28,10 +28,10 @@ ENV MAGENTO_ROOT /var/www/magento
 
 ENV DEBUG false
 
-ADD etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
-ADD etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
+COPY etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
+COPY etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
 
-ADD docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
@@ -40,7 +40,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
 
-ADD etc/php-fpm.ini /usr/local/etc/php/conf.d/zz-magento.ini
-ADD etc/php-fpm.conf /usr/local/etc/
+COPY etc/php-fpm.ini /usr/local/etc/php/conf.d/zz-magento.ini
+COPY etc/php-fpm.conf /usr/local/etc/
 
 CMD ["php-fpm", "-R"]

--- a/data/php-fpm/Dockerfile
+++ b/data/php-fpm/Dockerfile
@@ -28,10 +28,10 @@ ENV MAGENTO_ROOT /var/www/magento
 
 ENV DEBUG false
 
-ADD etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
-ADD etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
+COPY etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini
+COPY etc/mail.ini /usr/local/etc/php/conf.d/zz-mail.ini
 
-ADD docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
@@ -40,7 +40,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
 
-ADD etc/php-fpm.ini /usr/local/etc/php/conf.d/zz-magento.ini
-ADD etc/php-fpm.conf /usr/local/etc/
+COPY etc/php-fpm.ini /usr/local/etc/php/conf.d/zz-magento.ini
+COPY etc/php-fpm.conf /usr/local/etc/
 
 CMD ["php-fpm", "-R"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,8 +1,8 @@
 FROM nginx:1.9
 
-ADD etc/vhost.conf /etc/nginx/conf.d/default.conf
+COPY etc/vhost.conf /etc/nginx/conf.d/default.conf
 COPY etc/certs/ /etc/nginx/ssl/
-ADD bin/* /usr/local/bin/
+COPY bin/* /usr/local/bin/
 
 EXPOSE 443
 

--- a/varnish/Dockerfile
+++ b/varnish/Dockerfile
@@ -3,4 +3,4 @@ FROM million12/varnish
 ENV VCL_CONFIG /data/varnish.vcl
 ENV VARNISHD_PARAMS -p default_ttl=3600 -p default_grace=3600 -p feature=+esi_ignore_https -p feature=+esi_disable_xml_check
 
-ADD etc/varnish.vcl /data/varnish.vcl
+COPY etc/varnish.vcl /data/varnish.vcl


### PR DESCRIPTION
Hello,

The use of COPY is preferred over ADD when additional functionalities of ADD are not being used (like spraying the contents of a tar in a folder).

Ref:https://docs.docker.com/engine/articles/dockerfile_best-practices/#add-or-copy

Thanks.