### PR TITLE
MAGECLOUD-3030: [Cloud Docker] Varnish does not work for port 443 (SSL)

### DIFF
--- a/hitch/Dockerfile
+++ b/hitch/Dockerfile
@@ -1,0 +1,5 @@
+FROM zazukoians/hitch
+
+EXPOSE 443
+
+ENV HITCH_PARAMS "--backend=[varnish]:80 --frontend=[*]:443"


### PR DESCRIPTION
Adding Hitch image for SSL termination for Varnish