### PR TITLE
MAGECLOUD-2891: [Cloud Docker] Verify Xdebug functionality

### DIFF
--- a/data/php-cli/etc/php-xdebug.ini
+++ b/data/php-cli/etc/php-xdebug.ini
@@ -1,8 +1,8 @@
 ; Xdebug settings will only kick in if the Xdebug module is loaded
-
 xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 0
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = PHPSTORM

--- a/data/php-fpm/etc/php-xdebug.ini
+++ b/data/php-fpm/etc/php-xdebug.ini
@@ -1,7 +1,8 @@
 ; Xdebug settings will only kick in if the Xdebug module is loaded
 xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 0
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = PHPSTORM

--- a/php/7.0-cli/etc/php-xdebug.ini
+++ b/php/7.0-cli/etc/php-xdebug.ini
@@ -1,8 +1,8 @@
 ; Xdebug settings will only kick in if the Xdebug module is loaded
-
 xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 0
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = PHPSTORM

--- a/php/7.0-fpm/etc/php-xdebug.ini
+++ b/php/7.0-fpm/etc/php-xdebug.ini
@@ -1,7 +1,8 @@
 ; Xdebug settings will only kick in if the Xdebug module is loaded
 xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 0
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = PHPSTORM

--- a/php/7.1-cli/etc/php-xdebug.ini
+++ b/php/7.1-cli/etc/php-xdebug.ini
@@ -1,8 +1,8 @@
 ; Xdebug settings will only kick in if the Xdebug module is loaded
-
 xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 0
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = PHPSTORM

--- a/php/7.1-fpm/etc/php-xdebug.ini
+++ b/php/7.1-fpm/etc/php-xdebug.ini
@@ -1,7 +1,8 @@
 ; Xdebug settings will only kick in if the Xdebug module is loaded
 xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 0
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = PHPSTORM

--- a/php/7.2-cli/etc/php-xdebug.ini
+++ b/php/7.2-cli/etc/php-xdebug.ini
@@ -1,8 +1,8 @@
 ; Xdebug settings will only kick in if the Xdebug module is loaded
-
 xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 0
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = PHPSTORM

--- a/php/7.2-fpm/etc/php-xdebug.ini
+++ b/php/7.2-fpm/etc/php-xdebug.ini
@@ -1,7 +1,8 @@
 ; Xdebug settings will only kick in if the Xdebug module is loaded
 xdebug.remote_enable = 1
-xdebug.remote_connect_back = 1
-xdebug.remote_port = 9000
+xdebug.remote_port = 9001
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 0
 xdebug.scream = 0
 xdebug.show_local_vars = 1
 xdebug.idekey = PHPSTORM


### PR DESCRIPTION
https://magento2.atlassian.net/browse/MAGECLOUD-2891
A fixed configuration in xdebug.ini files. 
As 9000 port is reserved for php-fpm port for xdebug was changed to 9001.  `xdebug.remote_connect_back` switched to off as this option doesn't work for Windows and I think for Mac as well. Instead of `xdebug.remote_connect_back` was added `xdebug.remote_host` in `global.env` file and this option can be changed by dev depending on OS.