### PR TITLE
MAGECLOUD-3196: Add ElasticSearch 6.x Support to Cloud

### DIFF
--- a/elasticsearch/6.5/Dockerfile
+++ b/elasticsearch/6.5/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+
+RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+
+EXPOSE 9200 9300


### PR DESCRIPTION
Add ElasticSearch 6.x Support to Cloud