### PR TITLE
MAGECLOUD-3446: Add ICU and Phonetic Plugins to Elasticsearch Docker image

### DIFF
--- a/elasticsearch/1.7/Dockerfile
+++ b/elasticsearch/1.7/Dockerfile
@@ -1,5 +1,7 @@
 FROM elasticsearch:1.7
 
 RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN plugin --install elasticsearch/elasticsearch-analysis-icu/2.7.0 && \
+    plugin --install elasticsearch/elasticsearch-analysis-phonetic/2.7.0
 
 EXPOSE 9200 9300

--- a/elasticsearch/2.4/Dockerfile
+++ b/elasticsearch/2.4/Dockerfile
@@ -1,5 +1,7 @@
 FROM elasticsearch:2.4
 
 RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN bin/plugin install analysis-icu && \
+    bin/plugin install analysis-phonetic
 
 EXPOSE 9200 9300

--- a/elasticsearch/5.2/Dockerfile
+++ b/elasticsearch/5.2/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:5.2.2
 
 RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN bin/elasticsearch-plugin install analysis-icu && \
+    bin/elasticsearch-plugin install analysis-phonetic
 
 EXPOSE 9200 9300

--- a/elasticsearch/6.5/Dockerfile
+++ b/elasticsearch/6.5/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.4
 
 RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN bin/elasticsearch-plugin install analysis-icu && \
+    bin/elasticsearch-plugin install analysis-phonetic
 
 EXPOSE 9200 9300


### PR DESCRIPTION
### Description
As a developer I want my Docker containers to match P.sh's environments as closely as possible. The Elasticsearch service in P.sh has the ICU (analysis-icu) and Phonetic (analysis-phonetic) plugins installed by default. Those plugins should also be added to our Docker images.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
To build image from the custom branch you need to use 
- https://github.com/magento/magento-cloud-docker.git#MAGECLOUD-3446:elasticsearch/2.4 
- {URL}#{branch}:{dir}
then check that ES has `analysis-icu` and `analysis-phonetic` plugins. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
