### PR TITLE
MAGECLOUD-3832: [Cloud Docker] Update libsodium library

### DIFF
--- a/data/php-cli/Dockerfile
+++ b/data/php-cli/Dockerfile
@@ -5,11 +5,14 @@ ENV MAGENTO_ROOT /app
 ENV DEBUG false
 ENV MAGENTO_RUN_MODE production
 ENV COMPOSER_ALLOW_SUPERUSER 1
+{%env_php_extensions%}
 
 # Install dependencies
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
-  {%packages%}
+  {%packages%} \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure the gd library
 {%docker-php-ext-configure%}
@@ -18,6 +21,8 @@ RUN apt-get update \
 {%docker-php-ext-install%}
 
 {%php-pecl-extensions%}
+
+{%installation_scripts%}
 
 {%docker-php-ext-enable%}
 

--- a/data/php-extensions.php
+++ b/data/php-extensions.php
@@ -133,9 +133,35 @@ return [
     ],
     'sodium' => [
         '>=7.0.0 <7.2.0' => [
-            Php::EXTENSION_TYPE => Php::EXTENSION_TYPE_PECL,
-            Php::EXTENSION_OS_DEPENDENCIES => ['libsodium-dev'],
-            Php::EXTENSION_PACKAGE_NAME => 'libsodium',
+            Php::EXTENSION_TYPE => Php::EXTENSION_TYPE_INSTALLATION_SCRIPT,
+            Php::EXTENSION_INSTALLATION_SCRIPT => <<< BASH
+mkdir -p /tmp/libsodium 
+curl -sL https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz | tar xzf - -C  /tmp/libsodium
+cd /tmp/libsodium/libsodium-1.0.18-RELEASE/
+./configure
+make && make check
+make install 
+cd /
+rm -rf /tmp/libsodium 
+pecl install -o -f libsodium
+BASH
+        ],
+        '~7.2.0' => [
+            Php::EXTENSION_TYPE => Php::EXTENSION_TYPE_INSTALLATION_SCRIPT,
+            Php::EXTENSION_INSTALLATION_SCRIPT => <<< BASH
+rm -f /usr/local/etc/php/conf.d/*sodium.ini
+rm -f /usr/local/lib/php/extensions/*/*sodium.so
+apt-get remove libsodium* -y 
+mkdir -p /tmp/libsodium 
+curl -sL https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz | tar xzf - -C  /tmp/libsodium
+cd /tmp/libsodium/libsodium-1.0.18-RELEASE/
+./configure
+make && make check
+make install 
+cd /
+rm -rf /tmp/libsodium 
+pecl install -o -f libsodium
+BASH
         ]
     ],
     'ssh2' => [
@@ -184,7 +210,11 @@ return [
         ],
     ],
     'zip' => [
-        '>=7.0.0 <7.3.0' => [Php::EXTENSION_TYPE => Php::EXTENSION_TYPE_CORE],
+        '>=7.0.0 <7.3.0' => [
+            Php::EXTENSION_TYPE => Php::EXTENSION_TYPE_CORE,
+            Php::EXTENSION_OS_DEPENDENCIES => ['libzip-dev', 'zip'],
+            Php::EXTENSION_CONFIGURE_OPTIONS => ['--with-libzip'],
+        ],
     ],
     'pcntl' => [
         '>=7.0.0 <7.3.0' => [Php::EXTENSION_TYPE => Php::EXTENSION_TYPE_CORE],

--- a/data/php-fpm/Dockerfile
+++ b/data/php-fpm/Dockerfile
@@ -5,11 +5,14 @@ ENV MAGENTO_ROOT /app
 ENV DEBUG false
 ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
+{%env_php_extensions%}
 
 # Install dependencies
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
-  {%packages%}
+  {%packages%} \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure the gd library
 {%docker-php-ext-configure%}
@@ -18,6 +21,8 @@ RUN apt-get update \
 {%docker-php-ext-install%}
 
 {%php-pecl-extensions%}
+
+{%installation_scripts%}
 
 {%docker-php-ext-enable%}
 

--- a/php/7.0-cli/Dockerfile
+++ b/php/7.0-cli/Dockerfile
@@ -5,10 +5,13 @@ ENV MAGENTO_ROOT /app
 ENV DEBUG false
 ENV MAGENTO_RUN_MODE production
 ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mcrypt mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Install dependencies
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
+  apt-utils \
   sendmail-bin \
   sendmail \
   sudo \
@@ -37,12 +40,14 @@ RUN apt-get update \
   libpspell-dev \
   librecode0 \
   librecode-dev \
-  libsodium-dev \
   libssh2-1 \
   libssh2-1-dev \
   libtidy-dev \
   libxslt1-dev \
-  libyaml-dev
+  libyaml-dev \
+  libzip-dev \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -53,6 +58,8 @@ RUN docker-php-ext-configure \
   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \
   opcache --enable-opcache
+RUN docker-php-ext-configure \
+  zip --with-libzip
 
 # Install required PHP extensions
 RUN docker-php-ext-install -j$(nproc) \
@@ -94,10 +101,19 @@ RUN pecl install -o -f \
   propro \
   raphf \
   redis \
-  libsodium \
   ssh2-1.1.2 \
   xdebug-2.6.1 \
   yaml
+
+RUN mkdir -p /tmp/libsodium  \
+  && curl -sL https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz | tar xzf - -C  /tmp/libsodium \
+  && cd /tmp/libsodium/libsodium-1.0.18-RELEASE/ \
+  && ./configure \
+  && make && make check \
+  && make install  \
+  && cd / \
+  && rm -rf /tmp/libsodium  \
+  && pecl install -o -f libsodium
 
 RUN docker-php-ext-enable \
   bcmath \

--- a/php/7.0-fpm/Dockerfile
+++ b/php/7.0-fpm/Dockerfile
@@ -5,10 +5,13 @@ ENV MAGENTO_ROOT /app
 ENV DEBUG false
 ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mcrypt mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Install dependencies
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
+  apt-utils \
   sendmail-bin \
   sendmail \
   sudo \
@@ -29,12 +32,14 @@ RUN apt-get update \
   libpspell-dev \
   librecode0 \
   librecode-dev \
-  libsodium-dev \
   libssh2-1 \
   libssh2-1-dev \
   libtidy-dev \
   libxslt1-dev \
-  libyaml-dev
+  libyaml-dev \
+  libzip-dev \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -45,6 +50,8 @@ RUN docker-php-ext-configure \
   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \
   opcache --enable-opcache
+RUN docker-php-ext-configure \
+  zip --with-libzip
 
 # Install required PHP extensions
 RUN docker-php-ext-install -j$(nproc) \
@@ -86,10 +93,19 @@ RUN pecl install -o -f \
   propro \
   raphf \
   redis \
-  libsodium \
   ssh2-1.1.2 \
   xdebug-2.6.1 \
   yaml
+
+RUN mkdir -p /tmp/libsodium  \
+  && curl -sL https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz | tar xzf - -C  /tmp/libsodium \
+  && cd /tmp/libsodium/libsodium-1.0.18-RELEASE/ \
+  && ./configure \
+  && make && make check \
+  && make install  \
+  && cd / \
+  && rm -rf /tmp/libsodium  \
+  && pecl install -o -f libsodium
 
 RUN docker-php-ext-enable \
   bcmath \

--- a/php/7.1-cli/Dockerfile
+++ b/php/7.1-cli/Dockerfile
@@ -5,10 +5,13 @@ ENV MAGENTO_ROOT /app
 ENV DEBUG false
 ENV MAGENTO_RUN_MODE production
 ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mcrypt mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Install dependencies
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
+  apt-utils \
   sendmail-bin \
   sendmail \
   sudo \
@@ -37,12 +40,14 @@ RUN apt-get update \
   libpspell-dev \
   librecode0 \
   librecode-dev \
-  libsodium-dev \
   libssh2-1 \
   libssh2-1-dev \
   libtidy-dev \
   libxslt1-dev \
-  libyaml-dev
+  libyaml-dev \
+  libzip-dev \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -53,6 +58,8 @@ RUN docker-php-ext-configure \
   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \
   opcache --enable-opcache
+RUN docker-php-ext-configure \
+  zip --with-libzip
 
 # Install required PHP extensions
 RUN docker-php-ext-install -j$(nproc) \
@@ -94,10 +101,19 @@ RUN pecl install -o -f \
   propro \
   raphf \
   redis \
-  libsodium \
   ssh2-1.1.2 \
   xdebug-2.6.1 \
   yaml
+
+RUN mkdir -p /tmp/libsodium  \
+  && curl -sL https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz | tar xzf - -C  /tmp/libsodium \
+  && cd /tmp/libsodium/libsodium-1.0.18-RELEASE/ \
+  && ./configure \
+  && make && make check \
+  && make install  \
+  && cd / \
+  && rm -rf /tmp/libsodium  \
+  && pecl install -o -f libsodium
 
 RUN docker-php-ext-enable \
   bcmath \

--- a/php/7.1-fpm/Dockerfile
+++ b/php/7.1-fpm/Dockerfile
@@ -5,10 +5,13 @@ ENV MAGENTO_ROOT /app
 ENV DEBUG false
 ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mcrypt mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Install dependencies
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
+  apt-utils \
   sendmail-bin \
   sendmail \
   sudo \
@@ -29,12 +32,14 @@ RUN apt-get update \
   libpspell-dev \
   librecode0 \
   librecode-dev \
-  libsodium-dev \
   libssh2-1 \
   libssh2-1-dev \
   libtidy-dev \
   libxslt1-dev \
-  libyaml-dev
+  libyaml-dev \
+  libzip-dev \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -45,6 +50,8 @@ RUN docker-php-ext-configure \
   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \
   opcache --enable-opcache
+RUN docker-php-ext-configure \
+  zip --with-libzip
 
 # Install required PHP extensions
 RUN docker-php-ext-install -j$(nproc) \
@@ -86,10 +93,19 @@ RUN pecl install -o -f \
   propro \
   raphf \
   redis \
-  libsodium \
   ssh2-1.1.2 \
   xdebug-2.6.1 \
   yaml
+
+RUN mkdir -p /tmp/libsodium  \
+  && curl -sL https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz | tar xzf - -C  /tmp/libsodium \
+  && cd /tmp/libsodium/libsodium-1.0.18-RELEASE/ \
+  && ./configure \
+  && make && make check \
+  && make install  \
+  && cd / \
+  && rm -rf /tmp/libsodium  \
+  && pecl install -o -f libsodium
 
 RUN docker-php-ext-enable \
   bcmath \

--- a/php/7.2-cli/Dockerfile
+++ b/php/7.2-cli/Dockerfile
@@ -5,10 +5,13 @@ ENV MAGENTO_ROOT /app
 ENV DEBUG false
 ENV MAGENTO_RUN_MODE production
 ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Install dependencies
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
+  apt-utils \
   sendmail-bin \
   sendmail \
   sudo \
@@ -40,7 +43,10 @@ RUN apt-get update \
   libssh2-1-dev \
   libtidy-dev \
   libxslt1-dev \
-  libyaml-dev
+  libyaml-dev \
+  libzip-dev \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -51,6 +57,8 @@ RUN docker-php-ext-configure \
   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \
   opcache --enable-opcache
+RUN docker-php-ext-configure \
+  zip --with-libzip
 
 # Install required PHP extensions
 RUN docker-php-ext-install -j$(nproc) \
@@ -95,6 +103,19 @@ RUN pecl install -o -f \
   xdebug-2.6.1 \
   yaml
 
+RUN rm -f /usr/local/etc/php/conf.d/*sodium.ini \
+  && rm -f /usr/local/lib/php/extensions/*/*sodium.so \
+  && apt-get remove libsodium* -y  \
+  && mkdir -p /tmp/libsodium  \
+  && curl -sL https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz | tar xzf - -C  /tmp/libsodium \
+  && cd /tmp/libsodium/libsodium-1.0.18-RELEASE/ \
+  && ./configure \
+  && make && make check \
+  && make install  \
+  && cd / \
+  && rm -rf /tmp/libsodium  \
+  && pecl install -o -f libsodium
+
 RUN docker-php-ext-enable \
   bcmath \
   bz2 \
@@ -123,6 +144,7 @@ RUN docker-php-ext-enable \
   shmop \
   soap \
   sockets \
+  sodium \
   ssh2 \
   sysvmsg \
   sysvsem \

--- a/php/7.2-fpm/Dockerfile
+++ b/php/7.2-fpm/Dockerfile
@@ -5,10 +5,13 @@ ENV MAGENTO_ROOT /app
 ENV DEBUG false
 ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Install dependencies
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
+  apt-utils \
   sendmail-bin \
   sendmail \
   sudo \
@@ -32,7 +35,10 @@ RUN apt-get update \
   libssh2-1-dev \
   libtidy-dev \
   libxslt1-dev \
-  libyaml-dev
+  libyaml-dev \
+  libzip-dev \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -43,6 +49,8 @@ RUN docker-php-ext-configure \
   ldap --with-libdir=lib/x86_64-linux-gnu
 RUN docker-php-ext-configure \
   opcache --enable-opcache
+RUN docker-php-ext-configure \
+  zip --with-libzip
 
 # Install required PHP extensions
 RUN docker-php-ext-install -j$(nproc) \
@@ -87,6 +95,19 @@ RUN pecl install -o -f \
   xdebug-2.6.1 \
   yaml
 
+RUN rm -f /usr/local/etc/php/conf.d/*sodium.ini \
+  && rm -f /usr/local/lib/php/extensions/*/*sodium.so \
+  && apt-get remove libsodium* -y  \
+  && mkdir -p /tmp/libsodium  \
+  && curl -sL https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz | tar xzf - -C  /tmp/libsodium \
+  && cd /tmp/libsodium/libsodium-1.0.18-RELEASE/ \
+  && ./configure \
+  && make && make check \
+  && make install  \
+  && cd / \
+  && rm -rf /tmp/libsodium  \
+  && pecl install -o -f libsodium
+
 RUN docker-php-ext-enable \
   bcmath \
   bz2 \
@@ -115,6 +136,7 @@ RUN docker-php-ext-enable \
   shmop \
   soap \
   sockets \
+  sodium \
   ssh2 \
   sysvmsg \
   sysvsem \

--- a/src/Command/Generate/Php.php
+++ b/src/Command/Generate/Php.php
@@ -24,11 +24,13 @@ class Php extends Command
     private const EDITIONS = [self::EDITION_CLI, self::EDITION_FPM];
     private const ARGUMENT_VERSION = 'version';
     private const DEFAULT_PACKAGES_PHP_FPM = [
+        'apt-utils',
         'sendmail-bin',
         'sendmail',
         'sudo'
     ];
     private const DEFAULT_PACKAGES_PHP_CLI = [
+        'apt-utils',
         'sendmail-bin',
         'sendmail',
         'sudo',
@@ -42,13 +44,38 @@ class Php extends Command
         'vim',
     ];
 
+    private const PHP_EXTENSIONS_ENABLED_BY_DEFAULT = [
+        'bcmath',
+        'bz2',
+        'calendar',
+        'exif',
+        'gd',
+        'gettext',
+        'intl',
+        'mysqli',
+        'mcrypt',
+        'pcntl',
+        'pdo_mysql',
+        'soap',
+        'sockets',
+        'sysvmsg',
+        'sysvsem',
+        'sysvshm',
+        'redis',
+        'opcache',
+        'xsl',
+        'zip',
+    ];
+
     const DOCKERFILE = 'Dockerfile';
     const EXTENSION_OS_DEPENDENCIES = 'extension_os_dependencies';
     const EXTENSION_PACKAGE_NAME = 'extension_package_name';
     const EXTENSION_TYPE = 'extension_type';
     const EXTENSION_TYPE_PECL = 'extension_type_pecl';
     const EXTENSION_TYPE_CORE = 'extension_type_core';
+    const EXTENSION_TYPE_INSTALLATION_SCRIPT = 'extension_type_installation_script';
     const EXTENSION_CONFIGURE_OPTIONS = 'extension_configure_options';
+    const EXTENSION_INSTALLATION_SCRIPT = 'extension_installation_script';
 
     /**
      * @var Filesystem
@@ -92,7 +119,7 @@ class Php extends Command
     /**
      * {@inheritdoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
@@ -137,78 +164,90 @@ class Php extends Command
      * @param string $phpVersion
      * @param string $edition
      * @return string
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException|\RuntimeException
      */
     private function buildDockerfile(string $dockerfile, string $phpVersion, string $edition): string
     {
         $phpConstraintObject = new Constraint('==', $this->versionParser->normalize($phpVersion));
-        $extensionConfig = $this->filesystem->getRequire(DATA . '/php-extensions.php');
+        $phpExtConfigs = $this->filesystem->getRequire(DATA . '/php-extensions.php');
 
-        $dockerPhpExtInstall = [];
-        $phpPeclExtensions = [];
-        $extOsDependencies = [];
-        $dockerPhpExtConfigure = [];
-        $dockerPhpExtEnable = [];
+        $packages = self::EDITION_CLI == $edition ? self::DEFAULT_PACKAGES_PHP_CLI : self::DEFAULT_PACKAGES_PHP_FPM;
+        $phpExtCore = [];
+        $phpExtCoreConfigOptions = [];
+        $phpExtList = [];
+        $phpExtPecl = [];
+        $phpExtInstScripts = [];
+        $phpExtEnabledDefault = [];
 
-        foreach ($extensionConfig as $phpExtName => $phpExtConfig) {
-            if (empty($phpExtName)) {
-                throw new \RuntimeException('Extension name can\'t be empty');
+        foreach ($phpExtConfigs as $phpExtName => $phpExtConfig) {
+            if (!is_string($phpExtName)) {
+                throw new \RuntimeException('Extension name not set');
             }
             foreach ($phpExtConfig as $phpExtConstraint => $phpExtInstallConfig) {
                 $phpExtConstraintObject = $this->versionParser->parseConstraints($phpExtConstraint);
-                if ($phpConstraintObject->matches($phpExtConstraintObject)) {
-                    switch ($phpExtInstallConfig[self::EXTENSION_TYPE]) {
-                        case self::EXTENSION_TYPE_CORE:
-                            $dockerPhpExtInstall[] = $phpExtInstallConfig[self::EXTENSION_PACKAGE_NAME] ?? $phpExtName;
-                            break;
-                        case self::EXTENSION_TYPE_PECL:
-                            $phpPeclExtensions[] = $phpExtInstallConfig[self::EXTENSION_PACKAGE_NAME] ?? $phpExtName;
-                            break;
-                        default:
-                            throw new \RuntimeException(sprintf(
-                                "PHP extension %s. The type %s not supported",
-                                $phpExtName,
-                                $phpExtInstallConfig[self::EXTENSION_TYPE]
-                            ));
-                    }
-                    if (isset($phpExtInstallConfig[self::EXTENSION_OS_DEPENDENCIES])) {
-                        $extOsDependencies = array_merge(
-                            $extOsDependencies,
-                            $phpExtInstallConfig[self::EXTENSION_OS_DEPENDENCIES]
-                        );
-                    }
-                    if (isset($phpExtInstallConfig[self::EXTENSION_CONFIGURE_OPTIONS])) {
-                        $dockerPhpExtConfigure[] = sprintf(
-                            "RUN docker-php-ext-configure \\\n  %s %s",
-                            $phpExtName,
-                            implode(' ', $phpExtInstallConfig[self::EXTENSION_CONFIGURE_OPTIONS])
-                        );
-                    }
-
-                    $dockerPhpExtEnable[] = $phpExtName;
+                if (!$phpConstraintObject->matches($phpExtConstraintObject)) {
+                    continue;
                 }
+                $phpExtType = $phpExtInstallConfig[self::EXTENSION_TYPE];
+                switch ($phpExtType) {
+                    case self::EXTENSION_TYPE_CORE:
+                        $phpExtCore[] = $phpExtInstallConfig[self::EXTENSION_PACKAGE_NAME] ?? $phpExtName;
+                        if (isset($phpExtInstallConfig[self::EXTENSION_CONFIGURE_OPTIONS])) {
+                            $phpExtCoreConfigOptions[] = sprintf(
+                                "RUN docker-php-ext-configure \\\n  %s %s",
+                                $phpExtName,
+                                implode(' ', $phpExtInstallConfig[self::EXTENSION_CONFIGURE_OPTIONS])
+                            );
+                        }
+                        break;
+                    case self::EXTENSION_TYPE_PECL:
+                        $phpExtPecl[] = $phpExtInstallConfig[self::EXTENSION_PACKAGE_NAME] ?? $phpExtName;
+                        break;
+                    case self::EXTENSION_TYPE_INSTALLATION_SCRIPT:
+                        $phpExtInstScripts[] = implode(" \\\n", array_map(function (string $command) {
+                            return strpos($command, 'RUN') === false ? '  && ' . $command : $command;
+                        }, explode("\n", 'RUN ' . $phpExtInstallConfig[self::EXTENSION_INSTALLATION_SCRIPT])));
+                        break;
+                    default:
+                        throw new \RuntimeException(sprintf(
+                            "PHP extension %s. The type %s not supported",
+                            $phpExtName,
+                            $phpExtType
+                        ));
+                }
+                if (
+                    isset($phpExtInstallConfig[self::EXTENSION_OS_DEPENDENCIES])
+                    && $phpExtType != self::EXTENSION_TYPE_INSTALLATION_SCRIPT
+                ) {
+                    $packages = array_merge($packages, $phpExtInstallConfig[self::EXTENSION_OS_DEPENDENCIES]);
+                }
+                if (in_array($phpExtName, self::PHP_EXTENSIONS_ENABLED_BY_DEFAULT)) {
+                    $phpExtEnabledDefault[] = $phpExtName;
+                }
+                $phpExtList[] = $phpExtName;
             }
         }
-
-        $packages = array_merge(
-            self::EDITION_CLI == $edition ? self::DEFAULT_PACKAGES_PHP_CLI : self::DEFAULT_PACKAGES_PHP_FPM,
-            $extOsDependencies
-        );
 
         return strtr(
             $this->filesystem->get($dockerfile),
             [
                 '{%version%}' => $phpVersion,
                 '{%packages%}' => implode(" \\\n  ", array_unique($packages)),
-                '{%docker-php-ext-configure%}' => implode(PHP_EOL, $dockerPhpExtConfigure),
-                '{%docker-php-ext-install%}' => !empty($dockerPhpExtInstall)
-                    ? "RUN docker-php-ext-install -j$(nproc) \\\n  " . implode(" \\\n  ", $dockerPhpExtInstall)
+                '{%docker-php-ext-configure%}' => implode(PHP_EOL, $phpExtCoreConfigOptions),
+                '{%docker-php-ext-install%}' => !empty($phpExtCore)
+                    ? "RUN docker-php-ext-install -j$(nproc) \\\n  " . implode(" \\\n  ", $phpExtCore)
                     : '',
-                '{%php-pecl-extensions%}' => !empty($phpPeclExtensions)
-                    ? "RUN pecl install -o -f \\\n  " . implode(" \\\n  ", $phpPeclExtensions)
+                '{%php-pecl-extensions%}' => !empty($phpExtPecl)
+                    ? "RUN pecl install -o -f \\\n  " . implode(" \\\n  ", $phpExtPecl)
                     : '',
-                '{%docker-php-ext-enable%}' => !empty($dockerPhpExtEnable)
-                    ? "RUN docker-php-ext-enable \\\n  " . implode(" \\\n  ", $dockerPhpExtEnable)
+                '{%docker-php-ext-enable%}' => !empty($phpExtList)
+                    ? "RUN docker-php-ext-enable \\\n  " . implode(" \\\n  ", $phpExtList)
+                    : '',
+                '{%installation_scripts%}' => !empty($phpExtInstScripts)
+                    ? implode(PHP_EOL, $phpExtInstScripts)
+                    : '',
+                '{%env_php_extensions%}' => !(empty($phpExtEnabledDefault))
+                    ? 'ENV PHP_EXTENSIONS ' . implode(' ', $phpExtEnabledDefault)
                     : '',
             ]
         );


### PR DESCRIPTION
### Description
 Updates the libsodium library from version 1.0.11 to version 1.0.18 and updates the sodium PHP extension
### Fixed Issues (if relevant)
1. magento/magento-cloud-docker#MAGECLOUD-3832:[Cloud Docker] Update libsodium library

Tests:
https://jira.corp.magento.com/browse/MAGECLOUD-130
https://jira.corp.magento.com/browse/MAGECLOUD-131
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
