### PR TITLE
Add Nodejs & Grunt-cli to PHP-CLI Images

### DIFF
--- a/data/php-cli/Dockerfile
+++ b/data/php-cli/Dockerfile
@@ -1,11 +1,14 @@
 FROM php:{%version%}-cli-stretch
 
-ENV PHP_MEMORY_LIMIT 2G
-ENV MAGENTO_ROOT /app
-ENV DEBUG false
-ENV MAGENTO_RUN_MODE production
-ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PHP_MEMORY_LIMIT=2G \
+    MAGENTO_ROOT=/app \
+    DEBUG=false \
+    MAGENTO_RUN_MODE=production \
+    COMPOSER_ALLOW_SUPERUSER=1
 {%env_php_extensions%}
+
+# Configure Node.js version
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 
 # Install dependencies
 RUN apt-get update \
@@ -17,6 +20,9 @@ RUN apt-get update \
 # Install PyYAML
 RUN pip3 install --upgrade setuptools \
     && pip3 install pyyaml
+
+# Install Grunt
+RUN npm install -g grunt-cli
 
 # Configure the gd library
 {%docker-php-ext-configure%}
@@ -39,18 +45,20 @@ VOLUME /root/.composer/cache
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 ADD bin/* /usr/local/bin/
-
 ADD docker-entrypoint.sh /docker-entrypoint.sh
-RUN ["chmod", "+x", "/docker-entrypoint.sh"]
-ENTRYPOINT ["/docker-entrypoint.sh"]
 
-RUN ["chmod", "+x", "/usr/local/bin/magento-installer"]
-RUN ["chmod", "+x", "/usr/local/bin/magento-command"]
-RUN ["chmod", "+x", "/usr/local/bin/ece-command"]
-RUN ["chmod", "+x", "/usr/local/bin/cloud-build"]
-RUN ["chmod", "+x", "/usr/local/bin/cloud-deploy"]
-RUN ["chmod", "+x", "/usr/local/bin/run-cron"]
-RUN ["chmod", "+x", "/usr/local/bin/run-hooks"]
+RUN ["chmod", "+x", \
+    "/docker-entrypoint.sh", \
+    "/usr/local/bin/magento-installer", \
+    "/usr/local/bin/magento-command", \
+    "/usr/local/bin/ece-command", \
+    "/usr/local/bin/cloud-build", \
+    "/usr/local/bin/cloud-deploy", \
+    "/usr/local/bin/run-cron", \
+    "/usr/local/bin/run-hooks" \
+]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 WORKDIR ${MAGENTO_ROOT}
 

--- a/php/7.0-cli/Dockerfile
+++ b/php/7.0-cli/Dockerfile
@@ -1,30 +1,34 @@
 FROM php:7.0-cli-stretch
 
-ENV PHP_MEMORY_LIMIT 2G
-ENV MAGENTO_ROOT /app
-ENV DEBUG false
-ENV MAGENTO_RUN_MODE production
-ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PHP_MEMORY_LIMIT=2G \
+    MAGENTO_ROOT=/app \
+    DEBUG=false \
+    MAGENTO_RUN_MODE=production \
+    COMPOSER_ALLOW_SUPERUSER=1
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mcrypt mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
+
+# Configure Node.js version
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 
 # Install dependencies
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
   apt-utils \
-  sendmail-bin \
-  sendmail \
-  sudo \
   cron \
-  rsyslog \
-  mariadb-client \
   git \
-  redis-tools \
+  mariadb-client \
+  nodejs \
   nano \
-  unzip \
-  vim \
   python3 \
   python3-pip \
+  redis-tools \
+  rsyslog \
+  sendmail \
+  sendmail-bin \
+  sudo \
+  unzip \
+  vim \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \
@@ -54,6 +58,9 @@ RUN apt-get update \
 # Install PyYAML
 RUN pip3 install --upgrade setuptools \
     && pip3 install pyyaml
+
+# Install Grunt
+RUN npm install -g grunt-cli
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -172,18 +179,20 @@ VOLUME /root/.composer/cache
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 ADD bin/* /usr/local/bin/
-
 ADD docker-entrypoint.sh /docker-entrypoint.sh
-RUN ["chmod", "+x", "/docker-entrypoint.sh"]
-ENTRYPOINT ["/docker-entrypoint.sh"]
 
-RUN ["chmod", "+x", "/usr/local/bin/magento-installer"]
-RUN ["chmod", "+x", "/usr/local/bin/magento-command"]
-RUN ["chmod", "+x", "/usr/local/bin/ece-command"]
-RUN ["chmod", "+x", "/usr/local/bin/cloud-build"]
-RUN ["chmod", "+x", "/usr/local/bin/cloud-deploy"]
-RUN ["chmod", "+x", "/usr/local/bin/run-cron"]
-RUN ["chmod", "+x", "/usr/local/bin/run-hooks"]
+RUN ["chmod", "+x", \
+    "/docker-entrypoint.sh", \
+    "/usr/local/bin/magento-installer", \
+    "/usr/local/bin/magento-command", \
+    "/usr/local/bin/ece-command", \
+    "/usr/local/bin/cloud-build", \
+    "/usr/local/bin/cloud-deploy", \
+    "/usr/local/bin/run-cron", \
+    "/usr/local/bin/run-hooks" \
+]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 WORKDIR ${MAGENTO_ROOT}
 

--- a/php/7.0-cli/bin/run-hooks
+++ b/php/7.0-cli/bin/run-hooks
@@ -40,7 +40,6 @@ def get_hooks(hook_name):
 
 # Main function.
 def main():
-
     if len(sys.argv) != 2:
         error_exit("Usage: run-hooks <hook-name>")
 

--- a/php/7.1-cli/Dockerfile
+++ b/php/7.1-cli/Dockerfile
@@ -1,30 +1,34 @@
 FROM php:7.1-cli-stretch
 
-ENV PHP_MEMORY_LIMIT 2G
-ENV MAGENTO_ROOT /app
-ENV DEBUG false
-ENV MAGENTO_RUN_MODE production
-ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PHP_MEMORY_LIMIT=2G \
+    MAGENTO_ROOT=/app \
+    DEBUG=false \
+    MAGENTO_RUN_MODE=production \
+    COMPOSER_ALLOW_SUPERUSER=1
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mcrypt mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
+
+# Configure Node.js version
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 
 # Install dependencies
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
   apt-utils \
-  sendmail-bin \
-  sendmail \
-  sudo \
   cron \
-  rsyslog \
-  mariadb-client \
   git \
-  redis-tools \
+  mariadb-client \
+  nodejs \
   nano \
-  unzip \
-  vim \
   python3 \
   python3-pip \
+  redis-tools \
+  rsyslog \
+  sendmail \
+  sendmail-bin \
+  sudo \
+  unzip \
+  vim \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \
@@ -54,6 +58,9 @@ RUN apt-get update \
 # Install PyYAML
 RUN pip3 install --upgrade setuptools \
     && pip3 install pyyaml
+
+# Install Grunt
+RUN npm install -g grunt-cli
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -172,18 +179,20 @@ VOLUME /root/.composer/cache
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 ADD bin/* /usr/local/bin/
-
 ADD docker-entrypoint.sh /docker-entrypoint.sh
-RUN ["chmod", "+x", "/docker-entrypoint.sh"]
-ENTRYPOINT ["/docker-entrypoint.sh"]
 
-RUN ["chmod", "+x", "/usr/local/bin/magento-installer"]
-RUN ["chmod", "+x", "/usr/local/bin/magento-command"]
-RUN ["chmod", "+x", "/usr/local/bin/ece-command"]
-RUN ["chmod", "+x", "/usr/local/bin/cloud-build"]
-RUN ["chmod", "+x", "/usr/local/bin/cloud-deploy"]
-RUN ["chmod", "+x", "/usr/local/bin/run-cron"]
-RUN ["chmod", "+x", "/usr/local/bin/run-hooks"]
+RUN ["chmod", "+x", \
+    "/docker-entrypoint.sh", \
+    "/usr/local/bin/magento-installer", \
+    "/usr/local/bin/magento-command", \
+    "/usr/local/bin/ece-command", \
+    "/usr/local/bin/cloud-build", \
+    "/usr/local/bin/cloud-deploy", \
+    "/usr/local/bin/run-cron", \
+    "/usr/local/bin/run-hooks" \
+]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 WORKDIR ${MAGENTO_ROOT}
 

--- a/php/7.1-cli/bin/run-hooks
+++ b/php/7.1-cli/bin/run-hooks
@@ -40,7 +40,6 @@ def get_hooks(hook_name):
 
 # Main function.
 def main():
-
     if len(sys.argv) != 2:
         error_exit("Usage: run-hooks <hook-name>")
 

--- a/php/7.2-cli/Dockerfile
+++ b/php/7.2-cli/Dockerfile
@@ -1,30 +1,34 @@
 FROM php:7.2-cli-stretch
 
-ENV PHP_MEMORY_LIMIT 2G
-ENV MAGENTO_ROOT /app
-ENV DEBUG false
-ENV MAGENTO_RUN_MODE production
-ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PHP_MEMORY_LIMIT=2G \
+    MAGENTO_ROOT=/app \
+    DEBUG=false \
+    MAGENTO_RUN_MODE=production \
+    COMPOSER_ALLOW_SUPERUSER=1
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
+
+# Configure Node.js version
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 
 # Install dependencies
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
   apt-utils \
-  sendmail-bin \
-  sendmail \
-  sudo \
   cron \
-  rsyslog \
-  mariadb-client \
   git \
-  redis-tools \
+  mariadb-client \
+  nodejs \
   nano \
-  unzip \
-  vim \
   python3 \
   python3-pip \
+  redis-tools \
+  rsyslog \
+  sendmail \
+  sendmail-bin \
+  sudo \
+  unzip \
+  vim \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \
@@ -53,6 +57,9 @@ RUN apt-get update \
 # Install PyYAML
 RUN pip3 install --upgrade setuptools \
     && pip3 install pyyaml
+
+# Install Grunt
+RUN npm install -g grunt-cli
 
 # Configure the gd library
 RUN docker-php-ext-configure \
@@ -172,18 +179,20 @@ VOLUME /root/.composer/cache
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 ADD bin/* /usr/local/bin/
-
 ADD docker-entrypoint.sh /docker-entrypoint.sh
-RUN ["chmod", "+x", "/docker-entrypoint.sh"]
-ENTRYPOINT ["/docker-entrypoint.sh"]
 
-RUN ["chmod", "+x", "/usr/local/bin/magento-installer"]
-RUN ["chmod", "+x", "/usr/local/bin/magento-command"]
-RUN ["chmod", "+x", "/usr/local/bin/ece-command"]
-RUN ["chmod", "+x", "/usr/local/bin/cloud-build"]
-RUN ["chmod", "+x", "/usr/local/bin/cloud-deploy"]
-RUN ["chmod", "+x", "/usr/local/bin/run-cron"]
-RUN ["chmod", "+x", "/usr/local/bin/run-hooks"]
+RUN ["chmod", "+x", \
+    "/docker-entrypoint.sh", \
+    "/usr/local/bin/magento-installer", \
+    "/usr/local/bin/magento-command", \
+    "/usr/local/bin/ece-command", \
+    "/usr/local/bin/cloud-build", \
+    "/usr/local/bin/cloud-deploy", \
+    "/usr/local/bin/run-cron", \
+    "/usr/local/bin/run-hooks" \
+]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 WORKDIR ${MAGENTO_ROOT}
 

--- a/php/7.2-cli/bin/run-hooks
+++ b/php/7.2-cli/bin/run-hooks
@@ -40,7 +40,6 @@ def get_hooks(hook_name):
 
 # Main function.
 def main():
-
     if len(sys.argv) != 2:
         error_exit("Usage: run-hooks <hook-name>")
 

--- a/src/Command/Generate/Php.php
+++ b/src/Command/Generate/Php.php
@@ -31,19 +31,20 @@ class Php extends Command
     ];
     private const DEFAULT_PACKAGES_PHP_CLI = [
         'apt-utils',
-        'sendmail-bin',
-        'sendmail',
-        'sudo',
         'cron',
-        'rsyslog',
-        'mariadb-client',
         'git',
-        'redis-tools',
+        'mariadb-client',
         'nano',
-        'unzip',
-        'vim',
+        'nodejs',
         'python3',
         'python3-pip',
+        'redis-tools',
+        'rsyslog',
+        'sendmail',
+        'sendmail-bin',
+        'sudo',
+        'unzip',
+        'vim',
     ];
 
     private const PHP_EXTENSIONS_ENABLED_BY_DEFAULT = [


### PR DESCRIPTION
### Description

Many grunt tasks that ship with Magento depend on running `php bin/magento`. In order to perform these tasks, Node must be installed along side PHP and Magento, so it must be added to the PHP-CLI containers.

### Fixed Issues (if relevant)

[MAGECLOUD-3953](https://magento2.atlassian.net/browse/MAGECLOUD-3953)

### Manual testing scenarios

[MAGECLOUD-135](https://jira.corp.magento.com/browse/MAGECLOUD-135)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
