### PR TITLE
Added optional argument to expose DB port

### DIFF
--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -43,7 +43,7 @@ class BuildCompose extends Command
     private const OPTION_NO_CRON = 'no-cron';
 
     /**
-     * Option key to service name map.
+     * Option key to name map.
      *
      * @var array
      */
@@ -55,6 +55,7 @@ class BuildCompose extends Command
         self::OPTION_ES => ServiceInterface::NAME_ELASTICSEARCH,
         self::OPTION_NODE => ServiceInterface::NAME_NODE,
         self::OPTION_RABBIT_MQ => ServiceInterface::NAME_RABBITMQ,
+        self::OPTION_EXPOSE_DB_PORT => ProductionBuilder::KEY_EXPOSE_DB_PORT
     ];
 
     /**
@@ -222,10 +223,6 @@ class BuildCompose extends Command
             DeveloperBuilder::KEY_SYNC_ENGINE => $syncEngine,
             ProductionBuilder::KEY_NO_CRON => $input->getOption(self::OPTION_NO_CRON)
         ]);
-
-        if($exposedDbPort = $input->getOption(self::OPTION_EXPOSE_DB_PORT)) {
-            $config->set(self::OPTION_EXPOSE_DB_PORT, $exposedDbPort);
-        }
 
         if (in_array(
             $input->getOption(self::OPTION_MODE),

--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -33,6 +33,7 @@ class BuildCompose extends Command
     private const OPTION_PHP = 'php';
     private const OPTION_NGINX = 'nginx';
     private const OPTION_DB = 'db';
+    private const OPTION_EXPOSE_DB_PORT = 'expose-db-port';
     private const OPTION_REDIS = 'redis';
     private const OPTION_ES = 'es';
     private const OPTION_RABBIT_MQ = 'rmq';
@@ -120,6 +121,12 @@ class BuildCompose extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'DB version'
+            )
+            ->addOption(
+                self::OPTION_EXPOSE_DB_PORT,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Expose DB port'
             )
             ->addOption(
                 self::OPTION_REDIS,
@@ -215,6 +222,10 @@ class BuildCompose extends Command
             DeveloperBuilder::KEY_SYNC_ENGINE => $syncEngine,
             ProductionBuilder::KEY_NO_CRON => $input->getOption(self::OPTION_NO_CRON)
         ]);
+
+        if($exposedDbPort = $input->getOption(self::OPTION_EXPOSE_DB_PORT)) {
+            $config->set(self::OPTION_EXPOSE_DB_PORT, $exposedDbPort);
+        }
 
         if (in_array(
             $input->getOption(self::OPTION_MODE),

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -34,6 +34,7 @@ class ProductionBuilder implements BuilderInterface
     public const SERVICE_PHP_FPM = ServiceFactory::SERVICE_FPM;
 
     public const KEY_NO_CRON = 'no-cron';
+    public const KEY_EXPOSE_DB_PORT = 'expose-db-port';
 
     /**
      * @var ServiceFactory
@@ -114,6 +115,8 @@ class ProductionBuilder implements BuilderInterface
         $phpVersion = $this->config->get(ServiceInterface::NAME_PHP) ?: $this->getPhpVersion();
         $dbVersion = $this->config->get(ServiceInterface::NAME_DB)
             ?: $this->getServiceVersion(ServiceInterface::NAME_DB);
+        $hostPort = $this->config->get(self::KEY_EXPOSE_DB_PORT);
+        $dbPorts = $hostPort ? "$hostPort:3306" : '3306';
 
         $services = [
             'db' => $this->serviceFactory->create(
@@ -121,7 +124,7 @@ class ProductionBuilder implements BuilderInterface
                 $dbVersion,
                 [
                     'hostname' => 'db.magento2.docker',
-                    'ports' => [3306],
+                    'ports' => [$dbPorts],
                     'networks' => [
                         'magento' => [
                             'aliases' => [


### PR DESCRIPTION
### Description

-  Added optional argument `--expose-db-port=<PORT>` to `bin/ece-docker build:compose` to expose DB port to the host

### Fixed Issues

-  magento/magento-cloud-docker#80: Open up port 3306 for Database
Internal issue: https://magento2.atlassian.net/browse/MAGECLOUD-4544

### Manual testing scenarios
1. Run `bin/ece-docker build:compose --expose-db-port=4000` to expose port 4000 to host
2. Run `bin/ece-docker build:compose` without `--expose-db-port` argument to hide DB from host (existing funcitonality)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
