### PR TITLE
Changed default filesync method in developer mode

### DIFF
--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -207,7 +207,7 @@ class BuildCompose extends Command
                     'File sync engine. Works only with developer mode. Available: (%s)',
                     implode(', ', DeveloperBuilder::SYNC_ENGINES_LIST)
                 ),
-                DeveloperBuilder::SYNC_ENGINE_DOCKER_SYNC
+                DeveloperBuilder::SYNC_ENGINE_NATIVE
             )
             ->addOption(
                 self::OPTION_NO_CRON,


### PR DESCRIPTION
### Description
Changes the default filesync method, trivial change but it solves the issue.

### Fixed Issues (if relevant)
1. magento/magento-cloud-docker#114: Make native sync the default sync in Developer mode

### Manual testing scenarios
1. `vendor/bin/ece-docker build:compose --mode developer`
2. You will see that docker-compose is set to native mode, and does not require mutagen

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
