### PR TITLE
Include ece-post-deploy in command usage

### DIFF
--- a/dist/bin/magento-docker
+++ b/dist/bin/magento-docker
@@ -14,7 +14,8 @@ USAGE="Magento Cloud Docker
   restart           restart containers
   ece-build         build application
   ece-deploy        deploy application
-  ece-redeploy      re-build and re-deploy application
+  ece-post-deploy   run post-deploy hooks
+  ece-redeploy      re-build, re-deploy, and run post-deploy
 
 \033[33mOptions:\033[0m
   -h            show this help text\n"

--- a/dist/bin/magento-docker
+++ b/dist/bin/magento-docker
@@ -12,10 +12,10 @@ USAGE="Magento Cloud Docker
   stop              stop containers
   start             start containers
   restart           restart containers
-  ece-build         build application
-  ece-deploy        deploy application
+  ece-build         run build hooks
+  ece-deploy        run deploy hooks
   ece-post-deploy   run post-deploy hooks
-  ece-redeploy      re-build, re-deploy, and run post-deploy
+  ece-redeploy      run build, deploy, and post-deploy hooks
 
 \033[33mOptions:\033[0m
   -h            show this help text\n"


### PR DESCRIPTION
Updates the help for `bin/magento-docker` to include ece-post-deploy.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This updates the help for `bin/magento-docker` to include the ece-post-deploy command, which was added previously but is missing from the usage notes.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
_No issue filed._

### Manual testing scenarios
1. In a *nix environment, checkout the `magento/magento-cloud` template with `magento/magento-cloud-docker` 1.0.
1. Run `./bin/magento-docker ece-post-deploy` to confirm the functionality exists. Failure messages related to the installed state of Magento can be safely ignored, as they aren't related to the issue being tested.
1. Run `./bin/magento-docker` with no arguments.
    1. **Expected:** The displayed help mentions the `ece-post-deploy` command, and also mentions that `ece-redeploy` runs `ece-post-deploy` automatically. 
    1. **Actual:** `ece-post-deploy` is missing from the help and `ece-redeploy` is implied to skip post-deploy hooks.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
