### PR TITLE
Fixes MCD-100 and MCD-55

### DIFF
--- a/dist/mutagen.sh
+++ b/dist/mutagen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-mutagen terminate  --label-selector=magento-docker
-mutagen terminate  --label-selector=magento-docker-vendor
+mutagen terminate --label-selector=magento-docker
+mutagen terminate --label-selector=magento-docker-vendor
 
 mutagen create \
        --label=magento-docker \

--- a/dist/mutagen.sh
+++ b/dist/mutagen.sh
@@ -2,7 +2,6 @@
 mutagen terminate  --label-selector=magento-docker
 mutagen terminate  --label-selector=magento-docker-vendor
 
-
 mutagen create \
        --label=magento-docker \
        --sync-mode=two-way-resolved \
@@ -28,4 +27,3 @@ mutagen create \
        --default-directory-mode=0755 \
        --symlink-mode=posix-raw \
        ./vendor docker://$(docker-compose ps -q fpm|awk '{print $1}')/app/vendor
-

--- a/dist/mutagen.sh
+++ b/dist/mutagen.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+mutagen terminate  --label-selector=magento-docker
+mutagen terminate  --label-selector=magento-docker-vendor
+
+
 mutagen create \
        --label=magento-docker \
        --sync-mode=two-way-resolved \
@@ -8,6 +12,7 @@ mutagen create \
        --ignore=/.magento \
        --ignore=/.docker \
        --ignore=/.github \
+       --ignore=/vendor \
        --ignore=*.sql \
        --ignore=*.gz \
        --ignore=*.zip \
@@ -15,3 +20,12 @@ mutagen create \
        --ignore-vcs \
        --symlink-mode=posix-raw \
        ./ docker://$(docker-compose ps -q fpm|awk '{print $1}')/app
+
+mutagen create \
+       --label=magento-docker-vendor \
+       --sync-mode=two-way-resolved \
+       --default-file-mode=0644 \
+       --default-directory-mode=0755 \
+       --symlink-mode=posix-raw \
+       ./vendor docker://$(docker-compose ps -q fpm|awk '{print $1}')/app/vendor
+


### PR DESCRIPTION
### Description
This PR  modifies the Mutagen configuration, allowing for two things:
1) MCD-55: Makes it so mutagen does not create stale sessions by removing the sessions before it creates them, this uses the existing labels.
2) Adds a second mutagen sync session for vendor/

Of note: https://github.com/magento/magento-cloud-docker/pull/123 does not need to be merged, this PR includes that fix.

### Fixed Issues (if relevant)
1. magento/magento-cloud-docker#55: Mutagen Creates Multiple Stale Sessions
2. magento/magento-cloud-docker#100: Add separate Mutagen session for vendor directory

### Manual testing scenarios
1. See PR for 55: https://github.com/magento/magento-cloud-docker/pull/123 
2. Additionally, you will see two sync sessions when it is correctly running:
```[webuser@localhost ztgento]$ mutagen sync list
--------------------------------------------------------------------------------
Identifier: d7018ed0-db99-4ed4-b59a-eb430d46435c
Labels:
        magento-docker: <empty>
Alpha:
        URL: /home/webuser/docker/ztgento
        Connection state: Connected
Beta:
        URL: docker://b233a2a3ebe561cc592280473302ffe45b7848ad8bc531ab675c401980af7492/app
                DOCKER_HOST=
                DOCKER_TLS_VERIFY=
                DOCKER_CERT_PATH=
        Connection state: Connected
Status: Watching for changes
--------------------------------------------------------------------------------
Identifier: ef9b276a-8438-414b-b711-900814bb232c
Labels:
        magento-docker-vendor: <empty>
Alpha:
        URL: /home/webuser/docker/ztgento/vendor
        Connection state: Connected
Beta:
        URL: docker://b233a2a3ebe561cc592280473302ffe45b7848ad8bc531ab675c401980af7492/app/vendor
                DOCKER_HOST=
                DOCKER_TLS_VERIFY=
                DOCKER_CERT_PATH=
        Connection state: Connected
Status: Watching for changes
--------------------------------------------------------------------------------
```
### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
