### PR TITLE
Custom php.ini from root directory

### DIFF
--- a/images/php/7.1-cli/docker-entrypoint.sh
+++ b/images/php/7.1-cli/docker-entrypoint.sh
@@ -43,6 +43,9 @@ fi
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then

--- a/images/php/7.1-cli/docker-entrypoint.sh
+++ b/images/php/7.1-cli/docker-entrypoint.sh
@@ -39,11 +39,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 # Enable PHP extensions
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini

--- a/images/php/7.1-cli/docker-entrypoint.sh
+++ b/images/php/7.1-cli/docker-entrypoint.sh
@@ -39,12 +39,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 # Enable PHP extensions
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
-
-# Add custom php.ini if it exists
-[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 

--- a/images/php/7.1-fpm/docker-entrypoint.sh
+++ b/images/php/7.1-fpm/docker-entrypoint.sh
@@ -35,12 +35,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 # Enable PHP extensions
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
-
-# Add custom php.ini if it exists
-[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 

--- a/images/php/7.1-fpm/docker-entrypoint.sh
+++ b/images/php/7.1-fpm/docker-entrypoint.sh
@@ -39,6 +39,9 @@ fi
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then

--- a/images/php/7.1-fpm/docker-entrypoint.sh
+++ b/images/php/7.1-fpm/docker-entrypoint.sh
@@ -35,11 +35,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 # Enable PHP extensions
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini

--- a/images/php/7.2-cli/docker-entrypoint.sh
+++ b/images/php/7.2-cli/docker-entrypoint.sh
@@ -43,6 +43,9 @@ fi
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then

--- a/images/php/7.2-cli/docker-entrypoint.sh
+++ b/images/php/7.2-cli/docker-entrypoint.sh
@@ -39,11 +39,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 # Enable PHP extensions
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini

--- a/images/php/7.2-cli/docker-entrypoint.sh
+++ b/images/php/7.2-cli/docker-entrypoint.sh
@@ -39,12 +39,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 # Enable PHP extensions
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
-
-# Add custom php.ini if it exists
-[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 

--- a/images/php/7.2-fpm/docker-entrypoint.sh
+++ b/images/php/7.2-fpm/docker-entrypoint.sh
@@ -35,12 +35,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 # Enable PHP extensions
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
-
-# Add custom php.ini if it exists
-[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 

--- a/images/php/7.2-fpm/docker-entrypoint.sh
+++ b/images/php/7.2-fpm/docker-entrypoint.sh
@@ -39,6 +39,9 @@ fi
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then

--- a/images/php/7.2-fpm/docker-entrypoint.sh
+++ b/images/php/7.2-fpm/docker-entrypoint.sh
@@ -35,11 +35,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 # Enable PHP extensions
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini

--- a/images/php/7.3-cli/docker-entrypoint.sh
+++ b/images/php/7.3-cli/docker-entrypoint.sh
@@ -43,6 +43,9 @@ fi
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then

--- a/images/php/7.3-cli/docker-entrypoint.sh
+++ b/images/php/7.3-cli/docker-entrypoint.sh
@@ -39,11 +39,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 # Enable PHP extensions
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini

--- a/images/php/7.3-cli/docker-entrypoint.sh
+++ b/images/php/7.3-cli/docker-entrypoint.sh
@@ -39,12 +39,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 # Enable PHP extensions
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
-
-# Add custom php.ini if it exists
-[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 

--- a/images/php/7.3-fpm/docker-entrypoint.sh
+++ b/images/php/7.3-fpm/docker-entrypoint.sh
@@ -35,12 +35,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 # Enable PHP extensions
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
-
-# Add custom php.ini if it exists
-[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 

--- a/images/php/7.3-fpm/docker-entrypoint.sh
+++ b/images/php/7.3-fpm/docker-entrypoint.sh
@@ -39,6 +39,9 @@ fi
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini
 
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then

--- a/images/php/7.3-fpm/docker-entrypoint.sh
+++ b/images/php/7.3-fpm/docker-entrypoint.sh
@@ -35,11 +35,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 # Enable PHP extensions
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini

--- a/images/php/cli/docker-entrypoint.sh
+++ b/images/php/cli/docker-entrypoint.sh
@@ -39,6 +39,9 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 # Enable PHP extensions
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable

--- a/images/php/cli/docker-entrypoint.sh
+++ b/images/php/cli/docker-entrypoint.sh
@@ -39,11 +39,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 # Enable PHP extensions
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini

--- a/images/php/fpm/docker-entrypoint.sh
+++ b/images/php/fpm/docker-entrypoint.sh
@@ -35,6 +35,9 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+# Add custom php.ini if it exists
+[ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
+
 # Enable PHP extensions
 PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable

--- a/images/php/fpm/docker-entrypoint.sh
+++ b/images/php/fpm/docker-entrypoint.sh
@@ -35,11 +35,12 @@ if [ "$ENABLE_SENDMAIL" == "true" ]; then
     /etc/init.d/sendmail start
 fi
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
 
 # Enable PHP extensions
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 PHP_EXT_COM_ON=docker-php-ext-enable
 
 [ -d ${PHP_EXT_DIR} ] && rm -f ${PHP_EXT_DIR}/docker-php-ext-*.ini


### PR DESCRIPTION
### Description
This change adds a command to the entrypoint.sh which will copy in the php.ini from the root directory. This happens before the php-fpm service or cli command is run. 

This creates zzz-custom-php.ini which is named so it comes last, after all the default docker and magento extension configurations.

Windows/Mac users who are using file synchronization will need to ensure that the file sync is complete or the php.ini will not be copied into the configuration directory.


### Fixed Issues (if relevant)
1. magento/magento-cloud-docker#126: Add possibility to read php.ini

### Manual testing scenarios
1. See https://github.com/magento/devdocs/pull/6408 for details on how to import from custom docker image
2. Once you are building from vendor/magento/magento-cloud-docker/images/php/phpversion/ you should be able to test this.

Please let me know if you have any questions.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
