### PR TITLE
MAGECLOUD-5063: Cron container stops after starting on 1.0 images #132

### DIFF
--- a/images/php/7.1-cli/docker-entrypoint.sh
+++ b/images/php/7.1-cli/docker-entrypoint.sh
@@ -30,9 +30,16 @@ fi
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
 
+CRON_LOG=/var/log/cron.log
+
 if [ ! -z "${CRONTAB}" ]; then
     echo "${CRONTAB}" > /etc/cron.d/magento
 fi
+
+# Get rsyslog running for cron output
+touch $CRON_LOG
+echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+service rsyslog start
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/images/php/7.2-cli/docker-entrypoint.sh
+++ b/images/php/7.2-cli/docker-entrypoint.sh
@@ -30,9 +30,16 @@ fi
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
 
+CRON_LOG=/var/log/cron.log
+
 if [ ! -z "${CRONTAB}" ]; then
     echo "${CRONTAB}" > /etc/cron.d/magento
 fi
+
+# Get rsyslog running for cron output
+touch $CRON_LOG
+echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+service rsyslog start
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/images/php/7.3-cli/docker-entrypoint.sh
+++ b/images/php/7.3-cli/docker-entrypoint.sh
@@ -30,9 +30,16 @@ fi
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
 
+CRON_LOG=/var/log/cron.log
+
 if [ ! -z "${CRONTAB}" ]; then
     echo "${CRONTAB}" > /etc/cron.d/magento
 fi
+
+# Get rsyslog running for cron output
+touch $CRON_LOG
+echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+service rsyslog start
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/images/php/cli/docker-entrypoint.sh
+++ b/images/php/cli/docker-entrypoint.sh
@@ -30,9 +30,16 @@ fi
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
 
+CRON_LOG=/var/log/cron.log
+
 if [ ! -z "${CRONTAB}" ]; then
     echo "${CRONTAB}" > /etc/cron.d/magento
 fi
+
+# Get rsyslog running for cron output
+touch $CRON_LOG
+echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+service rsyslog start
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -462,13 +462,6 @@ class ProductionBuilder implements BuilderInterface
         }
 
         if (!$this->config->get(self::KEY_NO_TMP_MOUNTS)) {
-            $volumes['docker-tmp'] = [
-                'driver_opts' => [
-                    'type' => 'none',
-                    'device' => $rootPath . '/.docker/tmp',
-                    'o' => 'bind'
-                ]
-            ];
             $volumes['docker-mnt'] = [
                 'driver_opts' => [
                     'type' => 'none',
@@ -618,7 +611,7 @@ class ProductionBuilder implements BuilderInterface
             return [];
         }
 
-        return ['docker-mnt:/mnt', 'docker-tmp:/tmp'];
+        return ['docker-mnt:/mnt'];
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

* Fixes #132
* Fixes Mysql for Linux systems by removing `/tmp` from shared directories

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-5063
2. #132 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Build PHP container for cron services
2. Up containers and Magento
3. Run `docker-compose ps` to verify cron is running
4. Run `docker-compose logs cron` to verify there are no errors in cron container

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
