### PR TITLE
MAGECLOUD-4925: Ability to support custom database parameters in docker image

### DIFF
--- a/dist/mysql/mariadb.conf.d/example.cnf
+++ b/dist/mysql/mariadb.conf.d/example.cnf
@@ -1,0 +1,17 @@
+# This directory will be mounted in the 'db' service as '/etc/mysql/mariadb.conf.d'
+# and read by /etc/mysql/conf.d/mariadb.cnf.
+# All *.cnf files from the configuration directory will be applied to MariaDB configuration
+
+[client]
+# Default is Latin1, if you need UTF-8 set this (also in server section)
+#default-character-set = utf8
+#
+
+[mysqld]
+#
+# * Character sets
+#
+# Default is Latin1, if you need UTF-8 set all this (also in client section)
+#
+#character_set_server   = utf8
+#collation_server       = utf8_general_ci

--- a/dist/mysql/mariadb.conf.d/example.cnf
+++ b/dist/mysql/mariadb.conf.d/example.cnf
@@ -1,8 +1,11 @@
+#
 # This directory will be mounted in the 'db' service as '/etc/mysql/mariadb.conf.d'
 # and read by /etc/mysql/conf.d/mariadb.cnf.
 # All *.cnf files from the configuration directory will be applied to MariaDB configuration
+#
 
 [client]
+#
 # Default is Latin1, if you need UTF-8 set this (also in server section)
 #default-character-set = utf8
 #

--- a/src/Compose/BuilderInterface.php
+++ b/src/Compose/BuilderInterface.php
@@ -56,6 +56,7 @@ interface BuilderInterface
     public const VOLUME_MAGENTO_DEV = 'magento-dev';
     public const VOLUME_DOCKER_MNT = 'docker-mnt';
     public const VOLUME_DOCKER_ETRYPOINT = 'docker-entrypoint';
+    public const VOLUME_MARIADB_CONF = 'mariadb-conf';
 
     public const SYNC_ENGINE_NATIVE = 'native';
 

--- a/src/Compose/DeveloperBuilder.php
+++ b/src/Compose/DeveloperBuilder.php
@@ -158,14 +158,14 @@ class DeveloperBuilder implements BuilderInterface
      */
     private function getMagentoVolumes(Repository $config): array
     {
-        $target = self::DIR_MAGENTO;
-
         if ($config->get(self::KEY_SYNC_ENGINE) !== self::SYNC_ENGINE_NATIVE) {
-            $target .= ':nocopy';
+            return [
+                self::VOLUME_MAGENTO_SYNC . ':' . self::DIR_MAGENTO . ':nocopy'
+            ];
         }
 
         return [
-            self::VOLUME_MAGENTO_SYNC . ':' . $target . ':delegated',
+            self::VOLUME_MAGENTO_SYNC . ':' . self::DIR_MAGENTO . ':delegated',
         ];
     }
 }

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -183,7 +183,14 @@ class ProductionBuilder implements BuilderInterface
                     'device' => $this->resolver->getRootPath('/.docker/mysql/docker-entrypoint-initdb.d'),
                     'o' => 'bind'
                 ]
-            ]
+            ],
+            self::VOLUME_MARIADB_CONF => [
+                'driver_opts' => [
+                    'type' => 'none',
+                    'device' => $this->resolver->getRootPath('/.docker/mysql/mariadb.conf.d'),
+                    'o' => 'bind',
+                ],
+            ],
         ];
 
         if ($this->hasSelenium($config)) {
@@ -220,6 +227,16 @@ class ProductionBuilder implements BuilderInterface
             $volumes[$volumeName] = $syncConfig;
         }
 
+        if ($config->get(self::KEY_SYNC_ENGINE) === self::SYNC_ENGINE_MOUNT) {
+            $volumes[self::VOLUME_MAGENTO] = [
+                'driver_opts' => [
+                    'type' => 'none',
+                    'device' => $this->resolver->getRootPath(),
+                    'o' => 'bind'
+                ]
+            ];
+        }
+
         $manager->addVolumes($volumes);
 
         $volumesBuild = $this->volumeResolver->normalize(array_merge(
@@ -250,7 +267,7 @@ class ProductionBuilder implements BuilderInterface
                         [
                             self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
                             self::VOLUME_DOCKER_ETRYPOINT . ':/docker-entrypoint-initdb.d',
-                            '.docker/mysql/mariadb.conf.d:/etc/mysql/mariadb.conf.d',
+                            self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
                         ],
                         $volumesMount
                     )

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -216,7 +216,8 @@ class ProductionBuilder implements BuilderInterface
                     'volumes' => array_merge(
                         [
                             self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
-                            '.docker/mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d'
+                            '.docker/mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d',
+                            '.docker/mysql/mariadb.conf.d:/etc/mysql/mariadb.conf.d',
                         ],
                         $this->getMountVolumes($config)
                     )


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-4925

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Clone template: `git clone git@github.com:magento/magento-cloud.git`
2. Go to the project root directory: `cd magento-cloud`
3. Update dependencies: `composer update`
4. Build compose: `php vendor/bin/ece-docker build:compose`
5. Run containers: `docker-compose up -d`
6. Connect to `db` container: `docker-compose exec db bash`
7. Run cli command: `mysql -uroot -pmagento2 -e 'show variables WHERE Variable_name IN  ("collation_server", "character_set_server");' `
Expected result:
```
+----------------------+------------------+
| Variable_name        | Value            |
+----------------------+------------------+
| character_set_server | latin1           |
| collation_server     | latin1_swedish_ci|
+----------------------+------------------+
```
8. Create the file `./.docker/mysql/mariadb.conf.d/<any_name>.cnf` with next content:
```
# Use UTF8
[mysqld]
collation_server = utf8_general_ci
character_set_server = utf8
```
9. Run `docker-compose down -v && docker-compose up -d`
10. Connect to `db` container: `docker-compose exec db bash`
11. Run cli command: `mysql -uroot -pmagento2 -e 'show variables WHERE Variable_name IN  ("collation_server", "character_set_server");' `
Expected result:
```
+----------------------+-----------------+
| Variable_name        | Value           |
+----------------------+-----------------+
| character_set_server | utf8            |
| collation_server     | utf8_general_ci |
+----------------------+-----------------+
```
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
