### PR TITLE
MAGECLOUD-5181: Disable cron container by default

### DIFF
--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -209,12 +209,6 @@ class BuildCompose extends Command
                 DeveloperBuilder::SYNC_ENGINE_DOCKER_SYNC
             )
             ->addOption(
-                'no-cron',
-                null,
-                InputOption::VALUE_NONE,
-                '(Deprecated) Remove cron container'
-            )
-            ->addOption(
                 self::OPTION_WITH_CRON,
                 null,
                 InputOption::VALUE_NONE,

--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -50,7 +50,7 @@ class BuildCompose extends Command
     private const OPTION_NODE = 'node';
     private const OPTION_MODE = 'mode';
     private const OPTION_SYNC_ENGINE = 'sync-engine';
-    private const OPTION_NO_CRON = 'no-cron';
+    private const OPTION_WITH_CRON = 'with-cron';
     private const OPTION_WITH_SELENIUM = 'with-selenium';
 
     /**
@@ -209,10 +209,16 @@ class BuildCompose extends Command
                 DeveloperBuilder::SYNC_ENGINE_DOCKER_SYNC
             )
             ->addOption(
-                self::OPTION_NO_CRON,
+                'no-cron',
                 null,
                 InputOption::VALUE_NONE,
-                'Remove cron container'
+                '(Deprecated) Remove cron container'
+            )
+            ->addOption(
+                self::OPTION_WITH_CRON,
+                null,
+                InputOption::VALUE_NONE,
+                'Add cron container'
             )
             ->addOption(
                 self::OPTION_WITH_SELENIUM,
@@ -254,7 +260,7 @@ class BuildCompose extends Command
 
         $config->set([
             DeveloperBuilder::KEY_SYNC_ENGINE => $syncEngine,
-            ProductionBuilder::KEY_NO_CRON => $input->getOption(self::OPTION_NO_CRON),
+            ProductionBuilder::KEY_WITH_CRON=> $input->getOption(self::OPTION_WITH_CRON),
             ProductionBuilder::KEY_WITH_SELENIUM => $input->getOption(self::OPTION_WITH_SELENIUM)
         ]);
 

--- a/src/Compose/FunctionalBuilder.php
+++ b/src/Compose/FunctionalBuilder.php
@@ -86,7 +86,6 @@ class FunctionalBuilder extends ProductionBuilder
      */
     public function setConfig(Repository $config): void
     {
-        $config->set(self::KEY_NO_CRON, true);
         $config->set(self::KEY_WITH_SELENIUM, false);
         $config->set(self::KEY_NO_TMP_MOUNTS, true);
 

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -33,7 +33,7 @@ class ProductionBuilder implements BuilderInterface
     public const SERVICE_PHP_CLI = ServiceFactory::SERVICE_CLI;
     public const SERVICE_PHP_FPM = ServiceFactory::SERVICE_FPM;
 
-    public const KEY_NO_CRON = 'no-cron';
+    public const KEY_WITH_CRON = 'with-cron';
     public const KEY_EXPOSE_DB_PORT = 'expose-db-port';
     public const KEY_NO_TMP_MOUNTS = 'no-tmp-mounts';
     public const KEY_WITH_SELENIUM = 'with-selenium';
@@ -296,7 +296,7 @@ class ProductionBuilder implements BuilderInterface
             ]
         );
 
-        if (!$this->config->get(self::KEY_NO_CRON, false)) {
+        if ($this->config->get(self::KEY_WITH_CRON, false)) {
             $services['cron'] = $this->getCronCliService(
                 $phpVersion,
                 true,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento-cloud-docker/issues/139
2. https://magento2.atlassian.net/browse/MAGECLOUD-5181

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Build with default params
1. Verify there is no `cron` container
1. Verify environment works as expected
1. Build with `--with-cron`
1. Verify there is a `cron` container
1. Verify environment works as expected

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
