### PR TITLE
MAGECLOUD-4922: Email still trying to be sent when ENABLE_SENDMAIL=false is used

### DIFF
--- a/images/php/7.1-cli/docker-entrypoint.sh
+++ b/images/php/7.1-cli/docker-entrypoint.sh
@@ -41,12 +41,15 @@ touch $CRON_LOG
 echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
 service rsyslog start
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then
+    sed -i "s/!SENDMAIL_PATH!/\/usr\/sbin\/sendmail -t -i/" ${PHP_EXT_DIR}/zz-mail.ini
     /etc/init.d/sendmail start
+else
+    sed -i "s/!SENDMAIL_PATH!/\"true > \/dev\/null\"/" ${PHP_EXT_DIR}/zz-mail.ini
 fi
-
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Substitute in php.ini values
 [ ! -z "${PHP_MEMORY_LIMIT}" ] && sed -i "s/!PHP_MEMORY_LIMIT!/${PHP_MEMORY_LIMIT}/" ${PHP_EXT_DIR}/zz-magento.ini
@@ -63,6 +66,7 @@ PHP_EXT_COM_ON=docker-php-ext-enable
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then
       ${PHP_EXT_COM_ON} ${PHP_EXTENSIONS}
 fi
+
 
 # Configure composer
 [ ! -z "${COMPOSER_GITHUB_TOKEN}" ] && \

--- a/images/php/7.1-cli/etc/mail.ini
+++ b/images/php/7.1-cli/etc/mail.ini
@@ -1,2 +1,2 @@
 ; Sendmail
-sendmail_path=/usr/sbin/sendmail -t -i
+sendmail_path=!SENDMAIL_PATH!

--- a/images/php/7.1-fpm/docker-entrypoint.sh
+++ b/images/php/7.1-fpm/docker-entrypoint.sh
@@ -30,12 +30,15 @@ fi
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then
+    sed -i "s/!SENDMAIL_PATH!/\/usr\/sbin\/sendmail -t -i/" ${PHP_EXT_DIR}/zz-mail.ini
     /etc/init.d/sendmail start
+else
+    sed -i "s/!SENDMAIL_PATH!/\"true > \/dev\/null\"/" ${PHP_EXT_DIR}/zz-mail.ini
 fi
-
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Substitute in php.ini values
 [ ! -z "${PHP_MEMORY_LIMIT}" ] && sed -i "s/!PHP_MEMORY_LIMIT!/${PHP_MEMORY_LIMIT}/" ${PHP_EXT_DIR}/zz-magento.ini

--- a/images/php/7.1-fpm/etc/mail.ini
+++ b/images/php/7.1-fpm/etc/mail.ini
@@ -1,2 +1,2 @@
 ; Sendmail
-sendmail_path=/usr/sbin/sendmail -t -i
+sendmail_path=!SENDMAIL_PATH!

--- a/images/php/7.2-cli/docker-entrypoint.sh
+++ b/images/php/7.2-cli/docker-entrypoint.sh
@@ -41,12 +41,15 @@ touch $CRON_LOG
 echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
 service rsyslog start
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then
+    sed -i "s/!SENDMAIL_PATH!/\/usr\/sbin\/sendmail -t -i/" ${PHP_EXT_DIR}/zz-mail.ini
     /etc/init.d/sendmail start
+else
+    sed -i "s/!SENDMAIL_PATH!/\"true > \/dev\/null\"/" ${PHP_EXT_DIR}/zz-mail.ini
 fi
-
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Substitute in php.ini values
 [ ! -z "${PHP_MEMORY_LIMIT}" ] && sed -i "s/!PHP_MEMORY_LIMIT!/${PHP_MEMORY_LIMIT}/" ${PHP_EXT_DIR}/zz-magento.ini
@@ -63,6 +66,7 @@ PHP_EXT_COM_ON=docker-php-ext-enable
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then
       ${PHP_EXT_COM_ON} ${PHP_EXTENSIONS}
 fi
+
 
 # Configure composer
 [ ! -z "${COMPOSER_GITHUB_TOKEN}" ] && \

--- a/images/php/7.2-cli/etc/mail.ini
+++ b/images/php/7.2-cli/etc/mail.ini
@@ -1,2 +1,2 @@
 ; Sendmail
-sendmail_path=/usr/sbin/sendmail -t -i
+sendmail_path=!SENDMAIL_PATH!

--- a/images/php/7.2-fpm/docker-entrypoint.sh
+++ b/images/php/7.2-fpm/docker-entrypoint.sh
@@ -30,12 +30,15 @@ fi
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then
+    sed -i "s/!SENDMAIL_PATH!/\/usr\/sbin\/sendmail -t -i/" ${PHP_EXT_DIR}/zz-mail.ini
     /etc/init.d/sendmail start
+else
+    sed -i "s/!SENDMAIL_PATH!/\"true > \/dev\/null\"/" ${PHP_EXT_DIR}/zz-mail.ini
 fi
-
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Substitute in php.ini values
 [ ! -z "${PHP_MEMORY_LIMIT}" ] && sed -i "s/!PHP_MEMORY_LIMIT!/${PHP_MEMORY_LIMIT}/" ${PHP_EXT_DIR}/zz-magento.ini

--- a/images/php/7.2-fpm/etc/mail.ini
+++ b/images/php/7.2-fpm/etc/mail.ini
@@ -1,2 +1,2 @@
 ; Sendmail
-sendmail_path=/usr/sbin/sendmail -t -i
+sendmail_path=!SENDMAIL_PATH!

--- a/images/php/7.3-cli/docker-entrypoint.sh
+++ b/images/php/7.3-cli/docker-entrypoint.sh
@@ -41,12 +41,15 @@ touch $CRON_LOG
 echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
 service rsyslog start
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then
+    sed -i "s/!SENDMAIL_PATH!/\/usr\/sbin\/sendmail -t -i/" ${PHP_EXT_DIR}/zz-mail.ini
     /etc/init.d/sendmail start
+else
+    sed -i "s/!SENDMAIL_PATH!/\"true > \/dev\/null\"/" ${PHP_EXT_DIR}/zz-mail.ini
 fi
-
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Substitute in php.ini values
 [ ! -z "${PHP_MEMORY_LIMIT}" ] && sed -i "s/!PHP_MEMORY_LIMIT!/${PHP_MEMORY_LIMIT}/" ${PHP_EXT_DIR}/zz-magento.ini
@@ -54,7 +57,6 @@ PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Add custom php.ini if it exists
 [ -f "/app/php.ini" ] && cp /app/php.ini ${PHP_EXT_DIR}/zzz-custom-php.ini
-
 
 # Enable PHP extensions
 PHP_EXT_COM_ON=docker-php-ext-enable
@@ -64,6 +66,7 @@ PHP_EXT_COM_ON=docker-php-ext-enable
 if [ -x "$(command -v ${PHP_EXT_COM_ON})" ] && [ ! -z "${PHP_EXTENSIONS}" ]; then
       ${PHP_EXT_COM_ON} ${PHP_EXTENSIONS}
 fi
+
 
 # Configure composer
 [ ! -z "${COMPOSER_GITHUB_TOKEN}" ] && \

--- a/images/php/7.3-cli/etc/mail.ini
+++ b/images/php/7.3-cli/etc/mail.ini
@@ -1,2 +1,2 @@
 ; Sendmail
-sendmail_path=/usr/sbin/sendmail -t -i
+sendmail_path=!SENDMAIL_PATH!

--- a/images/php/7.3-fpm/docker-entrypoint.sh
+++ b/images/php/7.3-fpm/docker-entrypoint.sh
@@ -30,12 +30,15 @@ fi
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then
+    sed -i "s/!SENDMAIL_PATH!/\/usr\/sbin\/sendmail -t -i/" ${PHP_EXT_DIR}/zz-mail.ini
     /etc/init.d/sendmail start
+else
+    sed -i "s/!SENDMAIL_PATH!/\"true > \/dev\/null\"/" ${PHP_EXT_DIR}/zz-mail.ini
 fi
-
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Substitute in php.ini values
 [ ! -z "${PHP_MEMORY_LIMIT}" ] && sed -i "s/!PHP_MEMORY_LIMIT!/${PHP_MEMORY_LIMIT}/" ${PHP_EXT_DIR}/zz-magento.ini

--- a/images/php/7.3-fpm/etc/mail.ini
+++ b/images/php/7.3-fpm/etc/mail.ini
@@ -1,2 +1,2 @@
 ; Sendmail
-sendmail_path=/usr/sbin/sendmail -t -i
+sendmail_path=!SENDMAIL_PATH!

--- a/images/php/cli/docker-entrypoint.sh
+++ b/images/php/cli/docker-entrypoint.sh
@@ -41,12 +41,15 @@ touch $CRON_LOG
 echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
 service rsyslog start
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then
+    sed -i "s/!SENDMAIL_PATH!/\/usr\/sbin\/sendmail -t -i/" ${PHP_EXT_DIR}/zz-mail.ini
     /etc/init.d/sendmail start
+else
+    sed -i "s/!SENDMAIL_PATH!/\"true > \/dev\/null\"/" ${PHP_EXT_DIR}/zz-mail.ini
 fi
-
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Substitute in php.ini values
 [ ! -z "${PHP_MEMORY_LIMIT}" ] && sed -i "s/!PHP_MEMORY_LIMIT!/${PHP_MEMORY_LIMIT}/" ${PHP_EXT_DIR}/zz-magento.ini

--- a/images/php/cli/etc/mail.ini
+++ b/images/php/cli/etc/mail.ini
@@ -1,2 +1,2 @@
 ; Sendmail
-sendmail_path=/usr/sbin/sendmail -t -i
+sendmail_path=!SENDMAIL_PATH!

--- a/images/php/fpm/docker-entrypoint.sh
+++ b/images/php/fpm/docker-entrypoint.sh
@@ -30,12 +30,15 @@ fi
 # Ensure our Magento directory exists
 mkdir -p $MAGENTO_ROOT
 
+PHP_EXT_DIR=/usr/local/etc/php/conf.d
+
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then
+    sed -i "s/!SENDMAIL_PATH!/\/usr\/sbin\/sendmail -t -i/" ${PHP_EXT_DIR}/zz-mail.ini
     /etc/init.d/sendmail start
+else
+    sed -i "s/!SENDMAIL_PATH!/\"true > \/dev\/null\"/" ${PHP_EXT_DIR}/zz-mail.ini
 fi
-
-PHP_EXT_DIR=/usr/local/etc/php/conf.d
 
 # Substitute in php.ini values
 [ ! -z "${PHP_MEMORY_LIMIT}" ] && sed -i "s/!PHP_MEMORY_LIMIT!/${PHP_MEMORY_LIMIT}/" ${PHP_EXT_DIR}/zz-magento.ini

--- a/images/php/fpm/etc/mail.ini
+++ b/images/php/fpm/etc/mail.ini
@@ -1,2 +1,2 @@
 ; Sendmail
-sendmail_path=/usr/sbin/sendmail -t -i
+sendmail_path=!SENDMAIL_PATH!


### PR DESCRIPTION
### Description
Fixed the behavior when the environment variable ENABLE_SENDMAIL=false

### Fixed Issues (if relevant)
1. https://magento2.atlassian.net/browse/MAGECLOUD-4922

### Manual testing scenarios
1.  Build  the image: `# docker build --tag test-image ./images/php/7.x-<cli|fpm>/`
2. Run the image: `# docker run -it  --name test-container test-image bash`
3. Show the content from the `mail.ini` config file: `# cat /usr/local/etc/php/conf.d/zz-mail.ini`
    Expected results:
```
# cat /usr/local/etc/php/conf.d/zz-mail.ini
; Sendmail
sendmail_path="true > /dev/null"
```
4. Try to send a message: `# php -r "mail('<some@email.com>', 'Test Subject', 'Test Message');"`
5. The directory `mqueue-client` is empty:`# ls -al   /var/spool/mqueue-client/`
6. Remove the container: `# docker container rm  test-container`
7. Run the image with the environtment variable `ENABLE_SENDMAIL`: `# docker run -it --env ENABLE_SENDMAIL=true test-image bash`
8. Show content from the `mail.ini` config file: `# cat /usr/local/etc/php/conf.d/zz-mail.ini`
    Expected results:
```
# cat /usr/local/etc/php/conf.d/zz-mail.ini
; Sendmail
sendmail_path=/usr/sbin/sendmail -t -i
```
9. Sendmail process must be present: `ps aux | grep sendmail`
    Expected results:
```
# ps aux | grep sendmail
root        84  0.0  0.0  64932  4012 ?        Ss   23:05   0:00 sendmail: MTA: accepting connections
root       213  0.0  0.0  11112   968 pts/0    S+   23:05   0:00 grep sendmail
```
10. Try to send a message: `# php -r "mail('<some@email.com>', 'Test Subject', 'Test Message');" &`
11. Email sending processes must be present:  `ps aux | grep sendmail`
```
# ps aux | grep sendmail
root        84  0.0  0.0  64932  4012 ?        Ss   23:05   0:00 sendmail: MTA: accepting connections
root       222  0.0  0.0   4280   748 pts/0    S    23:09   0:00 sh -c /usr/sbin/sendmail -t -i
root       223  0.0  0.1  62292  6348 pts/0    S    23:09   0:00 /usr/sbin/sendmail -t -i
root       372  0.0  0.0  11112   940 pts/0    S+   23:09   0:00 grep sendmail
```
12. Wait for these processes to be completed.
13. The directory `mqueue-client` is not empty:`# ls -al   /var/spool/mqueue-client/`
```
# ls /var/spool/mqueue-client/
df015NA08j000223  qf015NA08j000223
```
### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
