### PR TITLE
MAGECLOUD-4894 : [MTS] Add support of split DB on docker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,14 @@
                 ".docker/mysql"
             ],
             [
+                "dist/mysql-sales",
+                ".docker/mysql-sales"
+            ],
+            [
+                "dist/mysql-quote",
+                ".docker/mysql-quote"
+            ],
+            [
                 "dist/bin/magento-docker",
                 "bin/magento-docker"
             ]

--- a/dist/mysql/mariadb.conf.d/example.cnf
+++ b/dist/mysql/mariadb.conf.d/example.cnf
@@ -1,0 +1,17 @@
+# This directory will be mounted in the 'db' service as '/etc/mysql/mariadb.conf.d'
+# and read by /etc/mysql/conf.d/mariadb.cnf.
+# All *.cnf files from the configuration directory will be applied to MariaDB configuration
+
+[client]
+# Default is Latin1, if you need UTF-8 set this (also in server section)
+#default-character-set = utf8
+#
+
+[mysqld]
+#
+# * Character sets
+#
+# Default is Latin1, if you need UTF-8 set all this (also in client section)
+#
+#character_set_server   = utf8
+#collation_server       = utf8_general_ci

--- a/dist/mysql/mariadb.conf.d/example.cnf
+++ b/dist/mysql/mariadb.conf.d/example.cnf
@@ -1,8 +1,11 @@
+#
 # This directory will be mounted in the 'db' service as '/etc/mysql/mariadb.conf.d'
 # and read by /etc/mysql/conf.d/mariadb.cnf.
 # All *.cnf files from the configuration directory will be applied to MariaDB configuration
+#
 
 [client]
+#
 # Default is Latin1, if you need UTF-8 set this (also in server section)
 #default-character-set = utf8
 #

--- a/src/Command/BuildCompose/SplitDbOptionValidator.php
+++ b/src/Command/BuildCompose/SplitDbOptionValidator.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CloudDocker\Command\BuildCompose;
+
+use Magento\CloudDocker\App\GenericException;
+use Magento\CloudDocker\Command\BuildCompose;
+use Magento\CloudDocker\Compose\ProductionBuilder;
+
+/**
+ * Validator for a value of the split-db option
+ */
+class SplitDbOptionValidator
+{
+    /**
+     * @param array $splitDbTypes
+     * @throws GenericException
+     */
+    public function validate(array $splitDbTypes)
+    {
+        $invalidSplitDbTypes = array_diff($splitDbTypes, ProductionBuilder::SPLIT_DB_TYPES);
+        if (!empty($invalidSplitDbTypes)) {
+            throw new GenericException(sprintf(
+                'The value [%s] is invalid of the option `%s`. Available: [%s]',
+                implode(' ', $invalidSplitDbTypes),
+                BuildCompose::OPTION_SPLIT_DB,
+                implode(' ', ProductionBuilder::SPLIT_DB_TYPES)
+            ));
+        }
+    }
+}

--- a/src/Command/BuildDist.php
+++ b/src/Command/BuildDist.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Magento\CloudDocker\Command;
 
 use Magento\CloudDocker\App\GenericException;
-use Magento\CloudDocker\App\GenericExceptionx;
 use Magento\CloudDocker\Command\BuildCompose\SplitDbOptionValidator;
 use Magento\CloudDocker\Compose\ProductionBuilder;
 use Magento\CloudDocker\Config\ConfigFactory;

--- a/src/Command/BuildDist.php
+++ b/src/Command/BuildDist.php
@@ -7,10 +7,16 @@ declare(strict_types=1);
 
 namespace Magento\CloudDocker\Command;
 
+use Magento\CloudDocker\App\GenericException;
+use Magento\CloudDocker\App\GenericExceptionx;
+use Magento\CloudDocker\Command\BuildCompose\SplitDbOptionValidator;
+use Magento\CloudDocker\Compose\ProductionBuilder;
+use Magento\CloudDocker\Config\ConfigFactory;
 use Magento\CloudDocker\Config\Dist\Generator;
 use Magento\CloudDocker\App\ConfigurationMismatchException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -20,17 +26,36 @@ class BuildDist extends Command
 {
     public const NAME = 'build:dist';
 
+    public const OPTION_SPLIT_DB = 'split-db';
+
     /**
      * @var Generator
      */
     private $distGenerator;
 
     /**
-     * @param Generator $distGenerator
+     * @var SplitDbOptionValidator
      */
-    public function __construct(Generator $distGenerator)
-    {
+    private $splitDbOptionValidator;
+
+    /**
+     * @var ConfigFactory
+     */
+    private $configFactory;
+
+    /**
+     * @param Generator $distGenerator
+     * @param SplitDbOptionValidator $splitDbOptionValidator
+     * @param ConfigFactory $configFactory
+     */
+    public function __construct(
+        Generator $distGenerator,
+        SplitDbOptionValidator $splitDbOptionValidator,
+        ConfigFactory $configFactory
+    ) {
         $this->distGenerator = $distGenerator;
+        $this->splitDbOptionValidator = $splitDbOptionValidator;
+        $this->configFactory = $configFactory;
 
         parent::__construct();
     }
@@ -41,17 +66,33 @@ class BuildDist extends Command
     protected function configure()
     {
         $this->setName(self::NAME)
-            ->setDescription('Generates Docker .dist files');
+            ->setDescription('Generates Docker .dist files')
+            ->addOption(
+                self::OPTION_SPLIT_DB,
+                null,
+                InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL,
+                'Adds additional database services for a split database architecture',
+                []
+            );
     }
 
     /**
      * {@inheritDoc}
      *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|void
      * @throws ConfigurationMismatchException
+     * @throws GenericException
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->distGenerator->generate();
+        $splitDbTypes = $input->getOption(self::OPTION_SPLIT_DB);
+        $this->splitDbOptionValidator->validate($splitDbTypes);
+        $config = $this->configFactory->create();
+        $config->set(ProductionBuilder::SPLIT_DB, $splitDbTypes);
+
+        $this->distGenerator->generate($config);
 
         $output->writeln('<info>Dist files generated</info>');
     }

--- a/src/Compose/BuilderInterface.php
+++ b/src/Compose/BuilderInterface.php
@@ -55,6 +55,8 @@ interface BuilderInterface
     public const VOLUME_MAGENTO_STATIC = 'magento-static';
     public const VOLUME_MAGENTO_MEDIA = 'magento-media';
     public const VOLUME_MAGENTO_DB = 'magento-db';
+    public const VOLUME_MAGENTO_DB_QUOTE = 'magento-db-quote';
+    public const VOLUME_MAGENTO_DB_SALES = 'magento-db-sales';
     public const VOLUME_MAGENTO_DEV = 'magento-dev';
     public const VOLUME_DOCKER_MNT = 'docker-mnt';
     public const VOLUME_DOCKER_ETRYPOINT = 'docker-entrypoint';

--- a/src/Compose/BuilderInterface.php
+++ b/src/Compose/BuilderInterface.php
@@ -56,6 +56,7 @@ interface BuilderInterface
     public const VOLUME_MAGENTO_DEV = 'magento-dev';
     public const VOLUME_DOCKER_MNT = 'docker-mnt';
     public const VOLUME_DOCKER_ETRYPOINT = 'docker-entrypoint';
+    public const VOLUME_MARIADB_CONF = 'mariadb-conf';
 
     public const SYNC_ENGINE_NATIVE = 'native';
 

--- a/src/Compose/BuilderInterface.php
+++ b/src/Compose/BuilderInterface.php
@@ -28,6 +28,8 @@ interface BuilderInterface
 
     public const SERVICE_GENERIC = 'generic';
     public const SERVICE_DB = 'db';
+    public const SERVICE_DB_QUOTE = 'db-quote';
+    public const SERVICE_DB_SALES = 'db-sales';
     public const SERVICE_FPM = 'fpm';
     public const SERVICE_BUILD = 'build';
     public const SERVICE_DEPLOY = 'deploy';
@@ -56,8 +58,9 @@ interface BuilderInterface
     public const VOLUME_MAGENTO_DEV = 'magento-dev';
     public const VOLUME_DOCKER_MNT = 'docker-mnt';
     public const VOLUME_DOCKER_ETRYPOINT = 'docker-entrypoint';
+    public const VOLUME_DOCKER_ETRYPOINT_QUOTE = 'docker-entrypoint-quote';
+    public const VOLUME_DOCKER_ETRYPOINT_SALES = 'docker-entrypoint-sales';
     public const VOLUME_MARIADB_CONF = 'mariadb-conf';
-
     public const SYNC_ENGINE_NATIVE = 'native';
 
     /**

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -183,7 +183,14 @@ class ProductionBuilder implements BuilderInterface
                     'device' => $this->resolver->getRootPath('/.docker/mysql/docker-entrypoint-initdb.d'),
                     'o' => 'bind'
                 ]
-            ]
+            ],
+            self::VOLUME_MARIADB_CONF => [
+                'driver_opts' => [
+                    'type' => 'none',
+                    'device' => $this->resolver->getRootPath('/.docker/mysql/mariadb.conf.d'),
+                    'o' => 'bind',
+                ],
+            ],
         ];
 
         if ($this->hasSelenium($config)) {
@@ -220,6 +227,16 @@ class ProductionBuilder implements BuilderInterface
             $volumes[$volumeName] = $syncConfig;
         }
 
+        if ($config->get(self::KEY_SYNC_ENGINE) === self::SYNC_ENGINE_MOUNT) {
+            $volumes[self::VOLUME_MAGENTO] = [
+                'driver_opts' => [
+                    'type' => 'none',
+                    'device' => $this->resolver->getRootPath(),
+                    'o' => 'bind'
+                ]
+            ];
+        }
+
         $manager->addVolumes($volumes);
 
         $volumesBuild = $this->volumeResolver->normalize(array_merge(
@@ -250,7 +267,7 @@ class ProductionBuilder implements BuilderInterface
                         [
                             self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
                             self::VOLUME_DOCKER_ETRYPOINT . ':/docker-entrypoint-initdb.d',
-                            '.docker/mysql/mariadb.conf.d:/etc/mysql/mariadb.conf.d',
+                            self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
                         ],
                         $volumesMount
                     )

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -303,7 +303,7 @@ class ProductionBuilder implements BuilderInterface
                         'ports' => [$dbPorts],
                         'volumes' => array_merge(
                             [
-                                self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
+//                                self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
                                 self::VOLUME_DOCKER_ETRYPOINT_QUOTE . ':/docker-entrypoint-initdb.d',
                                 self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
                             ],
@@ -336,7 +336,7 @@ class ProductionBuilder implements BuilderInterface
                         'ports' => [$dbPorts],
                         'volumes' => array_merge(
                             [
-                                self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
+//                                self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
                                 self::VOLUME_DOCKER_ETRYPOINT_SALES . ':/docker-entrypoint-initdb.d',
                                 self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
                             ],

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -216,7 +216,8 @@ class ProductionBuilder implements BuilderInterface
                     'volumes' => array_merge(
                         [
                             self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
-                            '.docker/mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d'
+                            '.docker/mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d',
+                            '.docker/mysql/mariadb.conf.d:/etc/mysql/mariadb.conf.d',
                         ],
                         $this->getMountVolumes($config)
                     )

--- a/src/Config/Dist/Generator.php
+++ b/src/Config/Dist/Generator.php
@@ -102,7 +102,6 @@ class Generator
             self::SPLIT_DB_TYPE_MAP,
             array_flip($splitDbTypes)
         );
-
         $resultConfig = array_merge(
             [
                 'MAGENTO_CLOUD_RELATIONSHIPS' => array_diff_key(

--- a/src/Config/Relationship.php
+++ b/src/Config/Relationship.php
@@ -17,6 +17,9 @@ use Magento\CloudDocker\Service\ServiceInterface;
  */
 class Relationship
 {
+    public const RELATIONSHIP_DATABASE = 'database';
+    public const RELATIONSHIP_DATABASE_SALES = 'database-sales';
+    public const RELATIONSHIP_DATABASE_QUOTE = 'database-quote';
     /**
      * @var Config
      */
@@ -28,9 +31,27 @@ class Relationship
      * @var array
      */
     private static $defaultConfiguration = [
-        'database' => [
+        self::RELATIONSHIP_DATABASE => [
             [
                 'host' => 'db',
+                'path' => 'magento2',
+                'password' => 'magento2',
+                'username' => 'magento2',
+                'port' => '3306'
+            ],
+        ],
+        self::RELATIONSHIP_DATABASE_SALES => [
+            [
+                'host' => 'db-sales',
+                'path' => 'magento2',
+                'password' => 'magento2',
+                'username' => 'magento2',
+                'port' => '3306'
+            ],
+        ],
+        self::RELATIONSHIP_DATABASE_QUOTE => [
+            [
+                'host' => 'db-quote',
                 'path' => 'magento2',
                 'password' => 'magento2',
                 'username' => 'magento2',
@@ -93,7 +114,9 @@ class Relationship
     private function convertServiceName(string $serviceName): string
     {
         $map = [
-            'database' => ServiceInterface::NAME_DB
+            'database' => ServiceInterface::NAME_DB,
+            'database-sales' => ServiceInterface::NAME_DB,
+            'database-quote' => ServiceInterface::NAME_DB,
         ];
 
         return $map[$serviceName] ?? $serviceName;

--- a/src/Test/Unit/Config/RelationshipTest.php
+++ b/src/Test/Unit/Config/RelationshipTest.php
@@ -43,7 +43,7 @@ class RelationshipTest extends TestCase
      */
     public function testGet()
     {
-        $this->configMock->expects($this->exactly(4))
+        $this->configMock->expects($this->exactly(6))
             ->method('getServiceVersion')
             ->willReturnMap([
                 ['mysql', '10'],


### PR DESCRIPTION
### Description
https://magento2.atlassian.net/browse/MAGECLOUD-4894
Adds the support of Split Db 

### Fixed Issues (if relevant)
1. https://magento2.atlassian.net/browse/MAGECLOUD-4894

### Manual testing scenarios
1. Run command `php vendor/bin/ece-docker build:compose`
   Expected results:
   The file `docker-compose.yaml` was generated without split Db services:
```
$ grep -E "(quote|sales)" ./docker-compose.yml

$ grep -E "(quote|sales)" ./.docker/config.php.dist

```
2. Run command `php vendor/bin/ece-docker build:compose --split-db=sales`
   Expected results:
   The file `docker-compose.yaml` was generated with 'db-sales' service:

```
db-sales:
    hostname: db-sales.magento2.docker
    image: 'mariadb:10.2'
    environment:
      - MYSQL_ROOT_PASSWORD=magento2
      - MYSQL_DATABASE=magento2
      - MYSQL_USER=magento2
      - MYSQL_PASSWORD=magento2
    ports:
      - '3306'
    volumes:
      - 'magento-db:/var/lib/mysql'
      - 'docker-entrypoint-sales:/docker-entrypoint-initdb.d'
      - 'mariadb-conf:/etc/mysql/mariadb.conf.d'
      - 'docker-mnt:/mnt:delegated'
    networks:
      magento:
        aliases:
          - db-sales.magento2.docker
```
     
The file `./.docker/config.php.dist` was generated with next configurations:

```
return [
    'MAGENTO_CLOUD_RELATIONSHIPS' => base64_encode(json_encode([
        ....
        'database-sales' => [
            [
                'host' => 'db-sales',
                'path' => 'magento2',
                'password' => 'magento2',
                'username' => 'magento2',
                'port' => '3306'
            ]
        ],
       ....
```

3. Run command `php vendor/bin/ece-docker build:compose --split-db=sales --split-db=quote`
   Expected results:
   The file `docker-compose.yaml` was generated with 'db-sales' and 'db-quote' services:

```
 db-quote:
    hostname: db-quote.magento2.docker
    image: 'mariadb:10.2'
    environment:
      - MYSQL_ROOT_PASSWORD=magento2
      - MYSQL_DATABASE=magento2
      - MYSQL_USER=magento2
      - MYSQL_PASSWORD=magento2
    ports:
      - '3306'
    volumes:
      - 'magento-db:/var/lib/mysql'
      - 'docker-entrypoint-quote:/docker-entrypoint-initdb.d'
      - 'mariadb-conf:/etc/mysql/mariadb.conf.d'
      - 'docker-mnt:/mnt:delegated'
    networks:
      magento:
        aliases:
          - db-quote.magento2.docker
  db-sales:
    hostname: db-sales.magento2.docker
    image: 'mariadb:10.2'
    environment:
      - MYSQL_ROOT_PASSWORD=magento2
      - MYSQL_DATABASE=magento2
      - MYSQL_USER=magento2
      - MYSQL_PASSWORD=magento2
    ports:
      - '3306'
    volumes:
      - 'magento-db:/var/lib/mysql'
      - 'docker-entrypoint-sales:/docker-entrypoint-initdb.d'
      - 'mariadb-conf:/etc/mysql/mariadb.conf.d'
      - 'docker-mnt:/mnt:delegated'
    networks:
      magento:
        aliases:
          - db-sales.magento2.docker
```
     
The file `./.docker/config.php.dist` was generated with next configurations:

```
return [
    'MAGENTO_CLOUD_RELATIONSHIPS' => base64_encode(json_encode([
        ....
       'database-sales' => [
            [
                'host' => 'db-sales',
                'path' => 'magento2',
                'password' => 'magento2',
                'username' => 'magento2',
                'port' => '3306'
            ]
        ],
        'database-quote' => [
            [
                'host' => 'db-quote',
                'path' => 'magento2',
                'password' => 'magento2',
                'username' => 'magento2',
                'port' => '3306'
            ]
        ],
       ....
```
4. Run `docker-compose up -d`
    Expected results:
    1. All services started successfully
5. Run command `docker-compose run deploy bash`
6. Run command in the container: ` echo $MAGENTO_CLOUD_RELATIONSHIPS | base64 -d | json_pp `
    Expected result:
```
{
   "database-quote" : [
      {
         "host" : "db-quote",
         "port" : "3306",
         "path" : "magento2",
         "username" : "magento2",
         "password" : "magento2"
      }
   ],
   "database-sales" : [
      {
         "path" : "magento2",
         "port" : "3306",
         "username" : "magento2",
         "host" : "db-sales",
         "password" : "magento2"
      }
   ],
   "database" : [
      {
         "username" : "magento2",
         "port" : "3306",
         "path" : "magento2",
         "host" : "db",
         "password" : "magento2"
      }
   ]
}
 ```





### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
