### PR TITLE
MAGECLOUD-5054: Add single quotes around alpine image in docker-compose.yml

### DIFF
--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -29,6 +29,7 @@ class ProductionBuilder implements BuilderInterface
     public const DEFAULT_NGINX_VERSION = 'latest';
     public const DEFAULT_VARNISH_VERSION = 'latest';
     public const DEFAULT_TLS_VERSION = 'latest';
+    public const DEFAULT_ALPINE_VERSION = 'latest';
 
     public const SERVICE_PHP_CLI = ServiceFactory::SERVICE_CLI;
     public const SERVICE_PHP_FPM = ServiceFactory::SERVICE_FPM;
@@ -287,7 +288,7 @@ class ProductionBuilder implements BuilderInterface
         $phpExtensions = $this->getPhpExtensions($phpVersion);
         $services['generic'] = $this->serviceFactory->create(
             ServiceFactory::SERVICE_GENERIC,
-            '',
+            self::DEFAULT_ALPINE_VERSION,
             [
                 'environment' => $this->converter->convert(array_merge(
                     $this->getVariables(),

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -123,7 +123,7 @@ class ServiceFactory
         ],
         self::SERVICE_GENERIC => [
             'image' => 'alpine',
-            'pattern' => '%s'
+            'pattern' => self::PATTERN_STD
         ],
         self::SERVICE_SELENIUM => [
             'image' => 'selenium/standalone-chrome',


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Adding version for alpine image.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-5054

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Clone a cloud template.
2. Make the following changes to the `composer.json` file.
```
    "repositories": {
        "repo": {
            "type": "composer",
            "url": "https://repo.magento.com"
        },
        "ece-tools": {
            "type": "vcs",
            "url": "https://github.com/magento/ece-tools"
        },
        "docker": {
            "type": "vcs",
            "url": "https://github.com/magento/magento-cloud-docker"
        }
    },
    "require": {
        "magento/magento-cloud-metapackage": ">=2.3.2 <2.3.3",
        "magento/ece-tools": "2002.1.0",
        "magento/magento-cloud-docker": "dev-MAGECLOUD-5054 as 1.0.99"
    }
```
3. Run `composer update`.
4. Generate the docker configuration file `docker-compose.yml` with `./vendor/bin/ece-docker build:compose`.
5. Inspect the `docker-compose.yml` file and ensure that the image for the generic service is `image: 'alpine:latest'`.
6. Launch docker with `docker-compose up -d`.
7. Build and deploy Magento in the container with `docker-compose run build cloud-build` and `docker-compose run deploy cloud-deploy` respectively.
8. Access local Magento (https://magento2.docker/) instance without errors.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
