### PR TITLE
MAGECLOUD-4168: Provide an Option to Specify Custom URL for Magento

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ git:
 addons:
   hosts:
     - magento2.docker
+    - magento2.test
 
 services:
   - docker

--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -205,6 +205,18 @@ class BuildCompose extends Command
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Cloud environment variables'
+            )
+            ->addOption(
+                Source\CliSource::OPTION_HOST,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Host name'
+            )
+            ->addOption(
+                Source\CliSource::OPTION_PORT,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Port'
             );
 
         parent::configure();

--- a/src/Compose/Manager.php
+++ b/src/Compose/Manager.php
@@ -12,7 +12,8 @@ namespace Magento\CloudDocker\Compose;
  */
 class Manager
 {
-    public const DOMAIN = 'magento2.docker';
+    public const DEFAULT_HOST = 'magento2.docker';
+    public const DEFAULT_PORT = '80';
 
     /**
      * @var string
@@ -35,6 +36,27 @@ class Manager
     private $volumes = [];
 
     /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var string
+     */
+    private $port;
+
+    /**
+     * @param string|null $host
+     * @param string|null $port
+     */
+    public function __construct(string $host = null, string $port = null)
+    {
+        $this->host = $host;
+        $this->port = $port;
+    }
+
+
+    /**
      * @param string $name
      * @param array $extConfig
      * @param array $networks
@@ -42,7 +64,7 @@ class Manager
      */
     public function addService(string $name, array $extConfig, array $networks, array $depends): void
     {
-        $hostname = $name . '.' . self::DOMAIN;
+        $hostname = $name . '.' . $this->getHost();
 
         $config = [
             'hostname' => $hostname,
@@ -170,5 +192,25 @@ class Manager
         ksort($this->networks);
 
         return $this->networks;
+    }
+
+    /**
+     * Returns host value or default if host not set
+     *
+     * @return string
+     */
+    public function getHost(): string
+    {
+        return $this->host ?? self::DEFAULT_HOST;
+    }
+
+    /**
+     * Returns port value or default if port not set
+     *
+     * @return string
+     */
+    public function getPort(): string
+    {
+        return $this->port ?? self::DEFAULT_PORT;
     }
 }

--- a/src/Compose/Manager.php
+++ b/src/Compose/Manager.php
@@ -7,14 +7,13 @@ declare(strict_types=1);
 
 namespace Magento\CloudDocker\Compose;
 
+use Magento\CloudDocker\Config\Config;
+
 /**
  * Compose configuration manager
  */
 class Manager
 {
-    public const DEFAULT_HOST = 'magento2.docker';
-    public const DEFAULT_PORT = '80';
-
     /**
      * @var string
      */
@@ -36,23 +35,16 @@ class Manager
     private $volumes = [];
 
     /**
-     * @var string
+     * @var Config
      */
-    private $host;
+    private $config;
 
     /**
-     * @var string
+     * @param Config $config
      */
-    private $port;
-
-    /**
-     * @param string|null $host
-     * @param string|null $port
-     */
-    public function __construct(string $host = null, string $port = null)
+    public function __construct(Config $config)
     {
-        $this->host = $host;
-        $this->port = $port;
+        $this->config = $config;
     }
 
     /**
@@ -63,7 +55,7 @@ class Manager
      */
     public function addService(string $name, array $extConfig, array $networks, array $depends): void
     {
-        $hostname = $name . '.' . $this->getHost();
+        $hostname = $name . '.' . $this->config->getHost();
 
         $config = [
             'hostname' => $hostname,
@@ -181,25 +173,5 @@ class Manager
         ksort($this->networks);
 
         return $this->networks;
-    }
-
-    /**
-     * Returns host value or default if host not set
-     *
-     * @return string
-     */
-    public function getHost(): string
-    {
-        return $this->host ?? self::DEFAULT_HOST;
-    }
-
-    /**
-     * Returns port value or default if port not set
-     *
-     * @return string
-     */
-    public function getPort(): string
-    {
-        return $this->port ?? self::DEFAULT_PORT;
     }
 }

--- a/src/Compose/Manager.php
+++ b/src/Compose/Manager.php
@@ -55,7 +55,6 @@ class Manager
         $this->port = $port;
     }
 
-
     /**
      * @param string $name
      * @param array $extConfig
@@ -109,16 +108,6 @@ class Manager
     public function addVolume(string $name, array $config): void
     {
         $this->volumes[$name] = $config;
-    }
-
-    /**
-     * @param array $volumes
-     */
-    public function addVolumes(array $volumes): void
-    {
-        foreach ($volumes as $name => $config) {
-            $this->volumes[$name] = $config;
-        }
     }
 
     /**

--- a/src/Compose/ManagerFactory.php
+++ b/src/Compose/ManagerFactory.php
@@ -7,6 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\CloudDocker\Compose;
 
+use Magento\CloudDocker\Config\Config;
+use Magento\CloudDocker\Config\Source\SourceInterface;
+
 /**
  * Creates instance of Manager
  *
@@ -14,8 +17,18 @@ namespace Magento\CloudDocker\Compose;
  */
 class ManagerFactory
 {
-    public function create(): Manager
+    /**
+     * Creates instance of Manager
+     *
+     * @param Config $config
+     * @return Manager
+     * @throws \Magento\CloudDocker\App\ConfigurationMismatchException
+     */
+    public function create(Config $config): Manager
     {
-        return new Manager();
+        return new Manager(
+            $config->get(SourceInterface::CONFIG_HOST),
+            $config->get(SourceInterface::CONFIG_PORT)
+        );
     }
 }

--- a/src/Compose/ManagerFactory.php
+++ b/src/Compose/ManagerFactory.php
@@ -26,9 +26,6 @@ class ManagerFactory
      */
     public function create(Config $config): Manager
     {
-        return new Manager(
-            $config->get(SourceInterface::CONFIG_HOST),
-            $config->get(SourceInterface::CONFIG_PORT)
-        );
+        return new Manager($config);
     }
 }

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -293,9 +293,12 @@ class ProductionBuilder implements BuilderInterface
                     'volumes' => $volumesRo,
                     'environment' => [
                         'VIRTUAL_HOST=' . $manager->getHost(),
-                        'VIRTUAL_PORT=' . $manager->getPort(),
+                        'VIRTUAL_PORT=80',
                         'HTTPS_METHOD=noredirect',
                         'WITH_XDEBUG=' . (int)$config->hasServiceEnabled(ServiceInterface::SERVICE_FPM_XDEBUG)
+                    ],
+                    'ports' => [
+                        $manager->getPort() . ':80'
                     ]
                 ]
             ),

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -312,7 +312,7 @@ class ProductionBuilder implements BuilderInterface
                     [
                         'networks' => [
                             self::NETWORK_MAGENTO => [
-                                'aliases' => $manager->getHost()
+                                'aliases' => [$manager->getHost()]
                             ]
                         ]
                     ]

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -292,13 +292,13 @@ class ProductionBuilder implements BuilderInterface
                 [
                     'volumes' => $volumesRo,
                     'environment' => [
-                        'VIRTUAL_HOST=' . $manager->getHost(),
+                        'VIRTUAL_HOST=' . $config->getHost(),
                         'VIRTUAL_PORT=80',
                         'HTTPS_METHOD=noredirect',
                         'WITH_XDEBUG=' . (int)$config->hasServiceEnabled(ServiceInterface::SERVICE_FPM_XDEBUG)
                     ],
                     'ports' => [
-                        $manager->getPort() . ':80'
+                        $config->getPort() . ':80'
                     ]
                 ]
             ),
@@ -315,7 +315,7 @@ class ProductionBuilder implements BuilderInterface
                     [
                         'networks' => [
                             self::NETWORK_MAGENTO => [
-                                'aliases' => [$manager->getHost()]
+                                'aliases' => [$config->getHost()]
                             ]
                         ]
                     ]

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -7,11 +7,11 @@ declare(strict_types=1);
 
 namespace Magento\CloudDocker\Compose;
 
+use Magento\CloudDocker\App\ConfigurationMismatchException;
 use Magento\CloudDocker\Compose\Php\ExtensionResolver;
 use Magento\CloudDocker\Compose\ProductionBuilder\VolumeResolver;
 use Magento\CloudDocker\Config\Config;
 use Magento\CloudDocker\Config\Environment\Converter;
-use Magento\CloudDocker\App\ConfigurationMismatchException;
 use Magento\CloudDocker\Filesystem\FileList;
 use Magento\CloudDocker\Service\ServiceFactory;
 use Magento\CloudDocker\Service\ServiceInterface;
@@ -134,7 +134,7 @@ class ProductionBuilder implements BuilderInterface
      */
     public function build(Config $config): Manager
     {
-        $manager = $this->managerFactory->create();
+        $manager = $this->managerFactory->create($config);
 
         $phpVersion = $config->getServiceVersion(ServiceInterface::SERVICE_PHP);
         $dbVersion = $config->getServiceVersion(ServiceInterface::SERVICE_DB);
@@ -292,8 +292,8 @@ class ProductionBuilder implements BuilderInterface
                 [
                     'volumes' => $volumesRo,
                     'environment' => [
-                        'VIRTUAL_HOST=magento2.docker',
-                        'VIRTUAL_PORT=80',
+                        'VIRTUAL_HOST=' . $manager->getHost(),
+                        'VIRTUAL_PORT=' . $manager->getPort(),
                         'HTTPS_METHOD=noredirect',
                         'WITH_XDEBUG=' . (int)$config->hasServiceEnabled(ServiceInterface::SERVICE_FPM_XDEBUG)
                     ]
@@ -312,7 +312,7 @@ class ProductionBuilder implements BuilderInterface
                     [
                         'networks' => [
                             self::NETWORK_MAGENTO => [
-                                'aliases' => [Manager::DOMAIN]
+                                'aliases' => $manager->getHost()
                             ]
                         ]
                     ]

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -9,6 +9,7 @@ namespace Magento\CloudDocker\Config;
 
 use Illuminate\Config\Repository;
 use Magento\CloudDocker\App\ConfigurationMismatchException;
+use Magento\CloudDocker\Config\Source\BaseSource;
 use Magento\CloudDocker\Config\Source\SourceException;
 use Magento\CloudDocker\Config\Source\SourceInterface;
 use Magento\CloudDocker\Service\ServiceInterface;
@@ -18,9 +19,6 @@ use Magento\CloudDocker\Service\ServiceInterface;
  */
 class Config
 {
-    public const DEFAULT_HOST = 'magento2.docker';
-    public const DEFAULT_PORT = '80';
-
     /**
      * @var SourceInterface[]
      */
@@ -253,7 +251,7 @@ class Config
      */
     public function getHost(): string
     {
-        return $this->get(SourceInterface::CONFIG_HOST) ?? self::DEFAULT_HOST;
+        return $this->get(SourceInterface::CONFIG_HOST) ?? BaseSource::DEFAULT_HOST;
     }
 
     /**
@@ -263,6 +261,6 @@ class Config
      */
     public function getPort(): string
     {
-        return $this->get(SourceInterface::CONFIG_PORT) ?? self::DEFAULT_PORT;
+        return $this->get(SourceInterface::CONFIG_PORT) ?? BaseSource::DEFAULT_PORT;
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -12,7 +12,6 @@ use Magento\CloudDocker\App\ConfigurationMismatchException;
 use Magento\CloudDocker\Compose\BuilderFactory;
 use Magento\CloudDocker\Compose\DeveloperBuilder;
 use Magento\CloudDocker\Compose\ProductionBuilder;
-use Magento\CloudDocker\Config\Source\BaseSource;
 use Magento\CloudDocker\Config\Source\SourceException;
 use Magento\CloudDocker\Config\Source\SourceInterface;
 use Magento\CloudDocker\Service\ServiceInterface;
@@ -300,7 +299,7 @@ class Config
      */
     public function getHost(): string
     {
-        return $this->get(SourceInterface::CONFIG_HOST) ?? BaseSource::DEFAULT_HOST;
+        return $this->get(SourceInterface::CONFIG_HOST);
     }
 
     /**
@@ -310,6 +309,6 @@ class Config
      */
     public function getPort(): string
     {
-        return $this->get(SourceInterface::CONFIG_PORT) ?? BaseSource::DEFAULT_PORT;
+        return $this->get(SourceInterface::CONFIG_PORT);
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -9,7 +9,6 @@ namespace Magento\CloudDocker\Config;
 
 use Illuminate\Config\Repository;
 use Magento\CloudDocker\App\ConfigurationMismatchException;
-use Magento\CloudDocker\Config\Source\CliSource;
 use Magento\CloudDocker\Config\Source\SourceException;
 use Magento\CloudDocker\Config\Source\SourceInterface;
 use Magento\CloudDocker\Service\ServiceInterface;
@@ -19,6 +18,9 @@ use Magento\CloudDocker\Service\ServiceInterface;
  */
 class Config
 {
+    public const DEFAULT_HOST = 'magento2.docker';
+    public const DEFAULT_PORT = '80';
+
     /**
      * @var SourceInterface[]
      */
@@ -242,5 +244,25 @@ class Config
         }
 
         return $config->get(SourceInterface::VARIABLES);
+    }
+
+    /**
+     * Returns host value or default if host not set
+     *
+     * @return string
+     */
+    public function getHost(): string
+    {
+        return $this->get(SourceInterface::CONFIG_HOST) ?? self::DEFAULT_HOST;
+    }
+
+    /**
+     * Returns port value or default if port not set
+     *
+     * @return string
+     */
+    public function getPort(): string
+    {
+        return $this->get(SourceInterface::CONFIG_PORT) ?? self::DEFAULT_PORT;
     }
 }

--- a/src/Config/Dist/Generator.php
+++ b/src/Config/Dist/Generator.php
@@ -163,10 +163,10 @@ class Generator
      */
     private function getBaseConfig(Config $config): array
     {
-        $host = $config->get(SourceInterface::CONFIG_HOST) ?? Manager::DEFAULT_HOST;
-        $port = $config->get(SourceInterface::CONFIG_PORT);
+        $host = $config->getHost();
+        $port = $config->getPort();
 
-        if (!empty($port) && $port != Manager::DEFAULT_PORT) {
+        if (!empty($port) && $port != Config::DEFAULT_PORT) {
             $host .= ':' . $port;
         }
 

--- a/src/Config/Dist/Generator.php
+++ b/src/Config/Dist/Generator.php
@@ -8,8 +8,10 @@ declare(strict_types=1);
 namespace Magento\CloudDocker\Config\Dist;
 
 use Magento\CloudDocker\App\ConfigurationMismatchException;
+use Magento\CloudDocker\Compose\Manager;
 use Magento\CloudDocker\Config\Config;
 use Magento\CloudDocker\Config\Relationship;
+use Magento\CloudDocker\Config\Source\SourceInterface;
 use Magento\CloudDocker\Filesystem\DirectoryList;
 use Magento\CloudDocker\Filesystem\Filesystem;
 use Magento\CloudDocker\Config\Environment\Shared\Reader as EnvReader;
@@ -50,27 +52,6 @@ class Generator
      * @var EnvCoder
      */
     private $envCoder;
-
-    /**
-     * @var array
-     */
-    private static $baseConfig = [
-        'MAGENTO_CLOUD_ROUTES' => [
-            'http://magento2.docker/' => [
-                'type' => 'upstream',
-                'original_url' => 'http://{default}'
-            ],
-            'https://magento2.docker/' => [
-                'type' => 'upstream',
-                'original_url' => 'https://{default}'
-            ],
-        ],
-        'MAGENTO_CLOUD_VARIABLES' => [
-            'ADMIN_EMAIL' => 'admin@example.com',
-            'ADMIN_PASSWORD' => '123123q',
-            'ADMIN_URL' => 'admin'
-        ],
-    ];
 
     /**
      * @param DirectoryList $directoryList
@@ -135,7 +116,7 @@ class Generator
     {
         return array_merge(
             ['MAGENTO_CLOUD_RELATIONSHIPS' => $this->relationship->get($config)],
-            self::$baseConfig
+            $this->getBaseConfig($config)
         );
     }
 
@@ -171,5 +152,35 @@ class Generator
         }
 
         $this->filesystem->put($filePath, $result);
+    }
+
+    /**
+     * Returns base configuration
+     *
+     * @param Config $config
+     * @return array
+     * @throws ConfigurationMismatchException
+     */
+    private function getBaseConfig(Config $config): array
+    {
+        $host = $config->get(SourceInterface::CONFIG_HOST) ?? Manager::DEFAULT_HOST;
+
+        return [
+            'MAGENTO_CLOUD_ROUTES' => [
+                sprintf('http://%s/', $host) => [
+                    'type' => 'upstream',
+                    'original_url' => 'http://{default}'
+                ],
+                sprintf('https://%s/', $host) => [
+                    'type' => 'upstream',
+                    'original_url' => 'https://{default}'
+                ],
+            ],
+            'MAGENTO_CLOUD_VARIABLES' => [
+                'ADMIN_EMAIL' => 'admin@example.com',
+                'ADMIN_PASSWORD' => '123123q',
+                'ADMIN_URL' => 'admin'
+            ],
+        ];
     }
 }

--- a/src/Config/Dist/Generator.php
+++ b/src/Config/Dist/Generator.php
@@ -164,6 +164,11 @@ class Generator
     private function getBaseConfig(Config $config): array
     {
         $host = $config->get(SourceInterface::CONFIG_HOST) ?? Manager::DEFAULT_HOST;
+        $port = $config->get(SourceInterface::CONFIG_PORT);
+
+        if (!empty($port) && $port != Manager::DEFAULT_PORT) {
+            $host .= ':' . $port;
+        }
 
         return [
             'MAGENTO_CLOUD_ROUTES' => [

--- a/src/Config/Dist/Generator.php
+++ b/src/Config/Dist/Generator.php
@@ -11,6 +11,7 @@ use Magento\CloudDocker\App\ConfigurationMismatchException;
 use Magento\CloudDocker\Compose\Manager;
 use Magento\CloudDocker\Config\Config;
 use Magento\CloudDocker\Config\Relationship;
+use Magento\CloudDocker\Config\Source\BaseSource;
 use Magento\CloudDocker\Config\Source\SourceInterface;
 use Magento\CloudDocker\Filesystem\DirectoryList;
 use Magento\CloudDocker\Filesystem\Filesystem;
@@ -166,7 +167,7 @@ class Generator
         $host = $config->getHost();
         $port = $config->getPort();
 
-        if (!empty($port) && $port != Config::DEFAULT_PORT) {
+        if (!empty($port) && $port != BaseSource::DEFAULT_PORT) {
             $host .= ':' . $port;
         }
 

--- a/src/Config/Source/BaseSource.php
+++ b/src/Config/Source/BaseSource.php
@@ -44,6 +44,8 @@ class BaseSource implements SourceInterface
             self::SYSTEM_MODE => BuilderFactory::BUILDER_PRODUCTION,
             self::SYSTEM_SYNC_ENGINE => null,
             self::CRON_ENABLED => false,
+            self::CONFIG_PORT => self::DEFAULT_PORT,
+            self::CONFIG_HOST => self::DEFAULT_HOST,
         ]);
 
         try {

--- a/src/Config/Source/BaseSource.php
+++ b/src/Config/Source/BaseSource.php
@@ -14,6 +14,9 @@ use Illuminate\Config\Repository;
  */
 class BaseSource implements SourceInterface
 {
+    public const DEFAULT_HOST = 'magento2.docker';
+    public const DEFAULT_PORT = '80';
+
     /**
      * @inheritDoc
      */

--- a/src/Config/Source/CliSource.php
+++ b/src/Config/Source/CliSource.php
@@ -49,6 +49,12 @@ class CliSource implements SourceInterface
     public const OPTION_ENV_VARIABLES = 'env-vars';
 
     /**
+     * Host configuration
+     */
+    public const OPTION_HOST = 'host';
+    public const OPTION_PORT = 'port';
+
+    /**
      * Option key to config name map
      *
      * @var array
@@ -171,8 +177,16 @@ class CliSource implements SourceInterface
             $repository->set(self::VARIABLES, (array) json_decode($envs, true));
         }
 
-        if ($port = $this->input->getOption(self::OPTION_EXPOSE_DB_PORT)) {
-            $repository->set(self::SYSTEM_EXPOSE_DB_PORTS, $port);
+        if ($dbPort = $this->input->getOption(self::OPTION_EXPOSE_DB_PORT)) {
+            $repository->set(self::SYSTEM_EXPOSE_DB_PORTS, $dbPort);
+        }
+
+        if ($host = $this->input->getOption(self::OPTION_HOST)) {
+            $repository->set(self::CONFIG_HOST, $host);
+        }
+
+        if ($port = $this->input->getOption(self::OPTION_PORT)) {
+            $repository->set(self::CONFIG_PORT, $port);
         }
 
         return $repository;

--- a/src/Config/Source/SourceInterface.php
+++ b/src/Config/Source/SourceInterface.php
@@ -94,6 +94,8 @@ interface SourceInterface
     public const CONFIG_SYNC_ENGINE = 'config.sync_engine';
     public const CONFIG_TMP_MOUNTS = 'config.tmp_mounts';
     public const CONFIG_MODE = 'config.mode';
+    public const CONFIG_HOST = 'config.host';
+    public const CONFIG_PORT = 'config.port';
     public const SYSTEM_EXPOSE_DB_PORTS = 'system.expose_db_ports';
 
     public const VARIABLES = 'variables';

--- a/src/Test/Functional/Acceptance/AcceptanceCest.php
+++ b/src/Test/Functional/Acceptance/AcceptanceCest.php
@@ -50,6 +50,22 @@ class AcceptanceCest
 
     /**
      * @param \CliTester $I
+     * @throws \Robo\Exception\TaskException
+     */
+    public function testCustomHost(\CliTester $I): void
+    {
+        $I->runEceDockerCommand('build:compose --mode=production --host=magento2.test --port=8080');
+        $I->startEnvironment();
+        $I->runDockerComposeCommand('run build cloud-build');
+        $I->runDockerComposeCommand('run deploy cloud-deploy');
+        $I->runDockerComposeCommand('run deploy cloud-post-deploy');
+        $I->amOnPage('/');
+        $I->see('Home page');
+        $I->see('CMS homepage content goes here.');
+    }
+
+    /**
+     * @param \CliTester $I
      */
     public function _after(\CliTester $I): void
     {

--- a/src/Test/Functional/Acceptance/AcceptanceCest.php
+++ b/src/Test/Functional/Acceptance/AcceptanceCest.php
@@ -60,7 +60,6 @@ class AcceptanceCest
         $I->runDockerComposeCommand('run build cloud-build');
         $I->runDockerComposeCommand('run deploy cloud-deploy');
         $I->runDockerComposeCommand('run deploy cloud-post-deploy');
-        $I->updateBaseUrl('magento2.test:8080');
         $I->amOnPage('/');
         $I->see('Home page');
         $I->see('CMS homepage content goes here.');

--- a/src/Test/Functional/Acceptance/AcceptanceCest.php
+++ b/src/Test/Functional/Acceptance/AcceptanceCest.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace Magento\CloudDocker\Test\Functional\Acceptance;
 
+use Codeception\Configuration;
+
 /**
  * @group php73
  */
@@ -54,6 +56,14 @@ class AcceptanceCest
      */
     public function testCustomHost(\CliTester $I): void
     {
+        Configuration::append([
+            'modules' => [
+                'config' => [
+                    ['PhpBrowser' => ['url' => 'magento2.test:8080']]
+                ]
+            ]
+        ]);
+
         $I->runEceDockerCommand('build:compose --mode=production --host=magento2.test --port=8080');
         $I->startEnvironment();
         $I->runDockerComposeCommand('run build cloud-build');

--- a/src/Test/Functional/Acceptance/AcceptanceCest.php
+++ b/src/Test/Functional/Acceptance/AcceptanceCest.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\CloudDocker\Test\Functional\Acceptance;
 
-use Codeception\Configuration;
-
 /**
  * @group php73
  */
@@ -56,19 +54,13 @@ class AcceptanceCest
      */
     public function testCustomHost(\CliTester $I): void
     {
-        Configuration::append([
-            'modules' => [
-                'config' => [
-                    ['PhpBrowser' => ['url' => 'magento2.test:8080']]
-                ]
-            ]
-        ]);
-
+        $I->updateBaseUrl('magento2.test:8080');
         $I->runEceDockerCommand('build:compose --mode=production --host=magento2.test --port=8080');
         $I->startEnvironment();
         $I->runDockerComposeCommand('run build cloud-build');
         $I->runDockerComposeCommand('run deploy cloud-deploy');
         $I->runDockerComposeCommand('run deploy cloud-post-deploy');
+        $I->updateBaseUrl('magento2.test:8080');
         $I->amOnPage('/');
         $I->see('Home page');
         $I->see('CMS homepage content goes here.');

--- a/src/Test/Functional/Acceptance/AcceptanceCest.php
+++ b/src/Test/Functional/Acceptance/AcceptanceCest.php
@@ -54,12 +54,15 @@ class AcceptanceCest
      */
     public function testCustomHost(\CliTester $I): void
     {
-        $I->updateBaseUrl('magento2.test:8080');
-        $I->runEceDockerCommand('build:compose --mode=production --host=magento2.test --port=8080');
+        $I->updateBaseUrl('http://magento2.test:8080/');
+        $I->assertTrue(
+            $I->runEceDockerCommand('build:compose --mode=production --host=magento2.test --port=8080'),
+            'Command build:compose failed'
+        );
         $I->startEnvironment();
-        $I->runDockerComposeCommand('run build cloud-build');
-        $I->runDockerComposeCommand('run deploy cloud-deploy');
-        $I->runDockerComposeCommand('run deploy cloud-post-deploy');
+        $I->assertTrue($I->runDockerComposeCommand('run build cloud-build'), 'Build phase failed');
+        $I->assertTrue($I->runDockerComposeCommand('run deploy cloud-deploy'), 'Deploy phase failed');
+        $I->assertTrue($I->runDockerComposeCommand('run deploy cloud-post-deploy'), 'Post deploy phase failed');
         $I->amOnPage('/');
         $I->see('Home page');
         $I->see('CMS homepage content goes here.');

--- a/src/Test/Unit/Config/Dist/GeneratorTest.php
+++ b/src/Test/Unit/Config/Dist/GeneratorTest.php
@@ -82,6 +82,8 @@ class GeneratorTest extends TestCase
     }
 
     /**
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     *
      * @throws ConfigurationMismatchException
      */
     public function testGenerate(): void
@@ -100,6 +102,12 @@ class GeneratorTest extends TestCase
                 'database' => ['config'],
                 'redis' => ['config'],
             ]);
+        $config->expects($this->exactly(1))
+            ->method('getHost')
+            ->willReturn('magento2.docker');
+        $config->expects($this->exactly(1))
+            ->method('getPort')
+            ->willReturn(80);
         $this->envReaderMock->expects($this->once())
             ->method('read')
             ->willReturn([]);

--- a/tests/functional/Codeception/BaseModule.php
+++ b/tests/functional/Codeception/BaseModule.php
@@ -68,6 +68,18 @@ class BaseModule extends Module implements BuilderAwareInterface, ContainerAware
     }
 
     /**
+     * Updates Base Url for PhpBrowser module
+     *
+     * @param string $url
+     * @throws \Codeception\Exception\ModuleConfigException
+     * @throws \Codeception\Exception\ModuleException
+     */
+    public function updateBaseUrl(string $url)
+    {
+        $this->getModule('PhpBrowser')->_reconfigure(['url' => $url]);
+    }
+
+    /**
      * Returns the path to work directory
      *
      * @return string


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Added possibility to configure hostname and port.

### Fixed Issues (if relevant)
https://magento2.atlassian.net/browse/MAGECLOUD-4168

### Manual testing scenarios
1. Launch Docker environment https://devdocs.magento.com/cloud/docker/docker-mode-production.html
2. Run build compose command with configured host `./vendor/bin/ece-docker build:compose --host=magento2.test`
3. After installation of Magento, check that site is accessible by `magento2.test` url not `magento2.docker`
4. Run `docker-compose down -v`
5. Launch Docker environment with configured port `./vendor/bin/ece-docker build:compose --host=magento2.test --port=8080`
6. Check that site is accessible by `magento2.test:8080` url not `magento2.docker`

releasenotes
Added the capability to configure the hostname and port in a local Docker environment using the `--host` and `--port` options in the `bin/magento2 build:compose` command. For example: `build:compose --host=magento2.local --port=8080`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
