### PR TITLE
MAGECLOUD-3243: OOTB Docker Startup

### DIFF
--- a/bin/init-docker.sh
+++ b/bin/init-docker.sh
@@ -52,7 +52,7 @@ composer_install()
 
 add_host()
 {
-    if [[ $(grep -Eq "^\s*\d+\.\d+\.\d+\.\d+\s+${DOMAIN}$" /etc/hosts) ]]; then
+    if grep -Eq "^\s*\d+\.\d+\.\d+\.\d+\s+${DOMAIN}$" /etc/hosts; then
         echo -e "\033[33m\033[1mThere is already an entry for $DOMAIN in /etc/hosts, skipping.\033[0m"
 
         return
@@ -75,8 +75,8 @@ USAGE="Init Docker
   \033[32m-h, --help\033[0m    show this help text
 
 \033[33mExample usage:\033[0m
-  \033[32mbin/init-docker.sh\033[0m                                  perform default actions
-  \033[32mbin/init-docker.sh --php 7.3 --host no --cert no\033[0m    use PHP 7.3 and skip some optional steps"
+  \033[32mbin/init-docker.sh\033[0m                        perform default actions
+  \033[32mbin/init-docker.sh --php 7.3 --host no\033[0m    use PHP 7.3, skip adding domain to /etc/hosts"
 
 while getopts "ht:p:-:" OPT; do
     if [ "$OPT" = "-" ]; then   # long option: reformulate OPT and OPTARG

--- a/bin/init-docker.sh
+++ b/bin/init-docker.sh
@@ -47,12 +47,12 @@ version_is_valid()
 
 composer_install()
 {
-    docker run --rm -it -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache "magento/magento-cloud-docker-php:${PHP_VERSION}-cli" composer install
+    docker run --rm -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache "magento/magento-cloud-docker-php:${PHP_VERSION}-cli" composer install --ansi
 }
 
 add_host()
 {
-    if ! [[ $(grep -Eq "^\s*\d+\.\d+\.\d+\.\d+\s+${DOMAIN}$" /etc/hosts) ]]; then
+    if [[ $(grep -Eq "^\s*\d+\.\d+\.\d+\.\d+\s+${DOMAIN}$" /etc/hosts) ]]; then
         echo -e "\033[33m\033[1mThere is already an entry for $DOMAIN in /etc/hosts, skipping.\033[0m"
 
         return

--- a/bin/init-docker.sh
+++ b/bin/init-docker.sh
@@ -79,17 +79,17 @@ USAGE="Init Docker
   Initialize a Magento Cloud Docker based project
 
 \033[33mOptions:\033[0m
-  \033[32m-p, --php\033[0m     PHP version (for installing dependencies) \033[33m[default: ${PHP_VERSION}]\033[0m
-  \033[32m-i, --image\033[0m   image version (for installing dependencies) \033[33m[default: ${IMAGE_VERSION}]\033[0m
-  \033[32m-d, --domain\033[0m  domain name to add to /etc/hosts \033[33m[default: ${DOMAIN}]\033[0m
-  \033[32m-t, --host\033[0m    add domain name to /etc/hosts file \033[33m[default: ${ADD_HOST}]\033[0m
-  \033[32m-h, --help\033[0m    show this help text
+  \033[32m-p, --php\033[0m        PHP version (for installing dependencies) \033[33m[default: ${PHP_VERSION}]\033[0m
+  \033[32m-i, --image\033[0m      image version (for installing dependencies) \033[33m[default: ${IMAGE_VERSION}]\033[0m
+  \033[32m    --host\033[0m       domain name to add to /etc/hosts \033[33m[default: ${DOMAIN}]\033[0m
+  \033[32m    --add-host\033[0m   add domain name to /etc/hosts file \033[33m[default: ${ADD_HOST}]\033[0m
+  \033[32m-h, --help\033[0m       show this help text
 
 \033[33mExample usage:\033[0m
-  \033[32mbin/init-docker.sh\033[0m                        perform default actions
-  \033[32mbin/init-docker.sh --php 7.3 --host no\033[0m    use PHP 7.3, skip adding domain to /etc/hosts"
+  \033[32mbin/init-docker.sh\033[0m                           perform default actions
+  \033[32mbin/init-docker.sh --php 7.3 --add-host no\033[0m   use PHP 7.3, skip adding domain to /etc/hosts"
 
-while getopts "ht:p:d:i:-:" OPT; do
+while getopts "hp:i:-:" OPT; do
     if [ "$OPT" = "-" ]; then   # long option: reformulate OPT and OPTARG
         OPT="${OPTARG%%=*}"       # extract long option name
 
@@ -110,13 +110,13 @@ while getopts "ht:p:d:i:-:" OPT; do
             IMAGE_VERSION="$OPTARG"
             ;;
 
-        t | host )
+        add-host )
             needs_arg "$@"
             parse_bool_flag
             ADD_HOST="$OPTARG"
             ;;
 
-        d | domain )
+        host )
             needs_arg "$@"
             domain_is_valid
             DOMAIN="$OPTARG"

--- a/bin/init-docker.sh
+++ b/bin/init-docker.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -e
+
+# complain to STDERR and exit with error
+die()
+{
+    echo "$*" >&2
+    print_usage
+    exit 2
+}
+
+print_usage()
+{
+    echo -e "$USAGE"
+}
+
+needs_arg()
+{
+    if [ -z "$OPTARG" ]; then
+        OPTARG="${!OPTIND}"
+        OPTIND=$(( $OPTIND + 1 ))
+    fi
+}
+
+parse_bool_flag()
+{
+    case "$(echo $OPTARG | tr '[:upper:]' '[:lower:]')" in
+        y | yes | t | true | 1 )
+            OPTARG=true
+            ;;
+        n | no | f | false | 0 )
+            OPTARG=false
+            ;;
+        * )
+            die "Invalid value $OPTARG for $OPT"
+            ;;
+    esac
+}
+
+version_is_valid()
+{
+    if [[ ! $OPTARG =~ ^[0-9]+\.[0-9]+$ ]]; then
+        die "Invalid version number $OPTARG for $OPT"
+    fi
+}
+
+composer_install()
+{
+    docker run --rm -it -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache "magento/magento-cloud-docker-php:${PHP_VERSION}-cli" composer install
+}
+
+add_host()
+{
+    if ! [[ $(grep -Eq "^\s*\d+\.\d+\.\d+\.\d+\s+${DOMAIN}$" /etc/hosts) ]]; then
+        echo -e "\033[33m\033[1mThere is already an entry for $DOMAIN in /etc/hosts, skipping.\033[0m"
+
+        return
+    fi
+
+    echo "127.0.0.1 $DOMAIN" | sudo tee -a /etc/hosts
+}
+
+PHP_VERSION="7.2"
+ADD_HOST=true
+DOMAIN="magento2.docker"
+USAGE="Init Docker
+
+\033[33mDescription:\033[0m
+  Initialize a Magento Cloud Docker based project
+
+\033[33mOptions:\033[0m
+  \033[32m-p, --php\033[0m     PHP version (for installing dependencies) \033[33m[default: ${PHP_VERSION}]\033[0m
+  \033[32m-t, --host\033[0m    add domain name to /etc/hosts file \033[33m[default: ${ADD_HOST}]\033[0m
+  \033[32m-h, --help\033[0m    show this help text
+
+\033[33mExample usage:\033[0m
+  \033[32mbin/init-docker.sh\033[0m                                  perform default actions
+  \033[32mbin/init-docker.sh --php 7.3 --host no --cert no\033[0m    use PHP 7.3 and skip some optional steps"
+
+while getopts "ht:p:-:" OPT; do
+    if [ "$OPT" = "-" ]; then   # long option: reformulate OPT and OPTARG
+        OPT="${OPTARG%%=*}"       # extract long option name
+
+        OPTARG="${OPTARG#$OPT}"   # extract long option argument (may be empty)
+        OPTARG="${OPTARG#=}"      # if long option argument, remove assigning `=`
+    fi
+
+    case "$OPT" in
+        p | php )
+            needs_arg "$@"
+            version_is_valid
+            PHP_VERSION="$OPTARG"
+            ;;
+
+        t | host )
+            needs_arg "$@"
+            parse_bool_flag
+            ADD_HOST="$OPTARG"
+            ;;
+
+        h | help )
+            print_usage
+            exit 0
+            ;;
+
+        \? )
+            print_usage
+            exit 1
+            ;;
+
+        ??* )
+            die "Illegal option --$OPT"
+            ;;
+    esac
+done
+
+shift $((OPTIND-1)) # remove parsed options and args from $@ list
+
+echo -e "\033[32m\033[1mInstalling Composer Packages\033[0m"
+composer_install
+
+if [ $ADD_HOST == true ]; then
+    echo -e "\033[32m\033[1mAdding $DOMAIN to /etc/hosts\033[0m"
+    echo -e "Your system password may be required"
+    add_host
+fi


### PR DESCRIPTION
### Description

Added shell script to initialize a fresh Magento Cloud project locally. It will:

1. Install the projects composer dependencies
2. Add `magento2.docker` to the hosts file, if it's not already there.

The script can either be run locally (if Magento Cloud Docker has already been installed as a dependency) or via piping a curl request into bash:

```bash
curl https://raw.githubusercontent.com/magento/magento-cloud-docker/MAGECLOUD-3243/bin/init-docker.sh | bash
```

Optional flags can be passed to select which version of PHP to use or disable adding the domain to /etch/hosts:

```bash
curl https://raw.githubusercontent.com/magento/magento-cloud-docker/MAGECLOUD-3243/bin/init-docker.sh | bash -s -- --php 7.3 --host no
```

### Fixed Issues (if relevant)

[MAGECLOUD-3243](https://magento2.atlassian.net/browse/MAGECLOUD-3243)

### Manual testing scenarios

Cd to a Magento Cloud project
Use the above example to run the script via curl
If the domain is already in /etc/hosts, a warning should be emitted and no duplicate entries should be added

Test that only supported flags may be passed
Test that `--add-host` only accepts "boolean" values
Test that `--php` or `-p` only accepts valid version numbers (e.g. `7.1`. There is no validation on whether the version number is a *real* PHP version, so for example the script will allow you to pass `8.4`)
Test that `--image` or `-i` only accepts valid version numbers (e.g. `1.0`)
Test that `--host` requires a value (no validation around whether the domain name is "valid")

### Future Additions

1. Ability to add the TLS container's cert to the local machine's trusted keychain. This was skipped because it would require the containers to be booted and I was concerned about wanting the user to have more flexibility there (this could be resolved with more research)
2. ~Ability to override the default domain with something else. I skipped this because I didn't want to get the user into an inconsistent state where `/etc/hosts` had a custom domain, but their generated configs had the default one. At this time, using a custom domain is probably best done fully manually so the user is aware of what they're doing. If customizing those values becomes simpler in the future, it may be easy to automate these steps through this script.~ *This has been added*

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
