### PR TITLE
MCLOUD-5859: Fix for conflicting volumes - #43

### DIFF
--- a/src/Compose/DeveloperBuilder.php
+++ b/src/Compose/DeveloperBuilder.php
@@ -148,7 +148,7 @@ class DeveloperBuilder implements BuilderInterface
                 $volumes,
                 [
                     $volumePrefix  . self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
-                    $volumePrefix  . self::VOLUME_DOCKER_ETRYPOINT . ':/docker-entrypoint-initdb.d',
+                    self::VOLUME_DOCKER_ETRYPOINT . ':/docker-entrypoint-initdb.d',
                     $volumePrefix  . self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
                 ]
             )

--- a/src/Compose/DeveloperBuilder.php
+++ b/src/Compose/DeveloperBuilder.php
@@ -57,7 +57,6 @@ class DeveloperBuilder implements BuilderInterface
      */
     private $extensionResolver;
 
-
     /**
      * @param BuilderFactory $builderFactory
      * @param FileList $fileList

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -107,7 +107,6 @@ class ProductionBuilder implements BuilderInterface
      * @param Resolver $resolver
      * @param VolumeResolver $volumeResolver
      */
-
     public function __construct(
         ServiceFactory $serviceFactory,
         FileList $fileList,
@@ -125,6 +124,7 @@ class ProductionBuilder implements BuilderInterface
         $this->resolver = $resolver;
         $this->volumeResolver = $volumeResolver;
     }
+
     /**
      * {@inheritdoc}
      *
@@ -144,8 +144,6 @@ class ProductionBuilder implements BuilderInterface
         $manager->addNetwork(self::NETWORK_MAGENTO, ['driver' => 'bridge']);
         $manager->addNetwork(self::NETWORK_MAGENTO_BUILD, ['driver' => 'bridge']);
 
-        $volumePrefix =  $config->getName() . '-';
-
         $volumes = [
             self::VOLUME_MAGENTO => [
                 'driver_opts' => [
@@ -154,8 +152,8 @@ class ProductionBuilder implements BuilderInterface
                     'o' => 'bind'
                 ]
             ],
-            $volumePrefix . self::VOLUME_MAGENTO_DB => [],
-            $volumePrefix . self::VOLUME_MARIADB_CONF => [
+            self::VOLUME_MAGENTO_DB => [],
+            self::VOLUME_MARIADB_CONF => [
                 'driver_opts' => [
                     'type' => 'none',
                     'device' => $this->resolver->getRootPath('/.docker/mysql/mariadb.conf.d'),
@@ -242,9 +240,9 @@ class ProductionBuilder implements BuilderInterface
                     'ports' => [$dbPorts],
                     'volumes' => array_merge(
                         [
-                            $volumePrefix . self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
+                            self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
                             self::VOLUME_DOCKER_ETRYPOINT . ':/docker-entrypoint-initdb.d',
-                            $volumePrefix . self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
+                            self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
                         ],
                         $volumesMount
                     )

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -144,6 +144,8 @@ class ProductionBuilder implements BuilderInterface
         $manager->addNetwork(self::NETWORK_MAGENTO, ['driver' => 'bridge']);
         $manager->addNetwork(self::NETWORK_MAGENTO_BUILD, ['driver' => 'bridge']);
 
+        $volumePrefix =  $config->getName() . '-';
+
         $volumes = [
             self::VOLUME_MAGENTO => [
                 'driver_opts' => [
@@ -152,8 +154,8 @@ class ProductionBuilder implements BuilderInterface
                     'o' => 'bind'
                 ]
             ],
-            self::VOLUME_MAGENTO_DB => [],
-            self::VOLUME_MARIADB_CONF => [
+            $volumePrefix . self::VOLUME_MAGENTO_DB => [],
+            $volumePrefix . self::VOLUME_MARIADB_CONF => [
                 'driver_opts' => [
                     'type' => 'none',
                     'device' => $this->resolver->getRootPath('/.docker/mysql/mariadb.conf.d'),
@@ -240,9 +242,9 @@ class ProductionBuilder implements BuilderInterface
                     'ports' => [$dbPorts],
                     'volumes' => array_merge(
                         [
-                            self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
+                            $volumePrefix . self::VOLUME_MAGENTO_DB . ':/var/lib/mysql',
                             self::VOLUME_DOCKER_ETRYPOINT . ':/docker-entrypoint-initdb.d',
-                            self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
+                            $volumePrefix . self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d',
                         ],
                         $volumesMount
                     )

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -98,7 +98,6 @@ class ProductionBuilder implements BuilderInterface
      */
     private $volumeResolver;
 
-
     /**
      * @param ServiceFactory $serviceFactory
      * @param FileList $fileList
@@ -108,6 +107,7 @@ class ProductionBuilder implements BuilderInterface
      * @param Resolver $resolver
      * @param VolumeResolver $volumeResolver
      */
+
     public function __construct(
         ServiceFactory $serviceFactory,
         FileList $fileList,
@@ -125,7 +125,6 @@ class ProductionBuilder implements BuilderInterface
         $this->resolver = $resolver;
         $this->volumeResolver = $volumeResolver;
     }
-
     /**
      * {@inheritdoc}
      *
@@ -135,9 +134,7 @@ class ProductionBuilder implements BuilderInterface
      */
     public function build(Config $config): Manager
     {
-        $volumePrefix =  $config->getName() . '-';
-
-        $manager = $this->managerFactory->create();
+        $manager = $this->managerFactory->create($config);
 
         $phpVersion = $config->getServiceVersion(ServiceInterface::SERVICE_PHP);
         $dbVersion = $config->getServiceVersion(ServiceInterface::SERVICE_DB);
@@ -146,6 +143,8 @@ class ProductionBuilder implements BuilderInterface
 
         $manager->addNetwork(self::NETWORK_MAGENTO, ['driver' => 'bridge']);
         $manager->addNetwork(self::NETWORK_MAGENTO_BUILD, ['driver' => 'bridge']);
+
+        $volumePrefix =  $config->getName() . '-';
 
         $volumes = [
             self::VOLUME_MAGENTO => [

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -311,4 +311,13 @@ class Config
     {
         return $this->get(SourceInterface::CONFIG_PORT);
     }
+
+    /**
+     * @return String
+     * @throws ConfigurationMismatchException
+     */
+    public function getName(): String
+    {
+        return $this->all()->get(SourceInterface::NAME);
+    }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -292,4 +292,13 @@ class Config
 
         return $config->get(SourceInterface::VARIABLES);
     }
+
+    /**
+     * @return String
+     * @throws ConfigurationMismatchException
+     */
+    public function getName(): String
+    {
+        return $this->all()->get(SourceInterface::NAME);
+    }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -12,7 +12,6 @@ use Magento\CloudDocker\App\ConfigurationMismatchException;
 use Magento\CloudDocker\Compose\BuilderFactory;
 use Magento\CloudDocker\Compose\DeveloperBuilder;
 use Magento\CloudDocker\Compose\ProductionBuilder;
-use Magento\CloudDocker\Config\Source\CliSource;
 use Magento\CloudDocker\Config\Source\SourceException;
 use Magento\CloudDocker\Config\Source\SourceInterface;
 use Magento\CloudDocker\Service\ServiceInterface;
@@ -294,11 +293,22 @@ class Config
     }
 
     /**
-     * @return String
-     * @throws ConfigurationMismatchException
+     * Returns host value or default if host not set
+     *
+     * @return string
      */
-    public function getName(): String
+    public function getHost(): string
     {
-        return $this->all()->get(SourceInterface::NAME);
+        return $this->get(SourceInterface::CONFIG_HOST);
+    }
+
+    /**
+     * Returns port value or default if port not set
+     *
+     * @return string
+     */
+    public function getPort(): string
+    {
+        return $this->get(SourceInterface::CONFIG_PORT);
     }
 }

--- a/src/Config/Source/CloudSource.php
+++ b/src/Config/Source/CloudSource.php
@@ -301,7 +301,7 @@ class CloudSource implements SourceInterface
     private function addName(Repository $repository, String $name): Repository
     {
         $repository->set([
-            "name" => $name,
+            self::NAME => $name,
         ]);
 
         return $repository;

--- a/src/Config/Source/CloudSource.php
+++ b/src/Config/Source/CloudSource.php
@@ -126,6 +126,10 @@ class CloudSource implements SourceInterface
             $repository,
             $appConfig['relationships'] ?? []
         );
+        $repository = $this->addName(
+            $repository,
+            $appConfig['name'] ?? []
+        );
 
         return $repository;
     }
@@ -189,14 +193,14 @@ class CloudSource implements SourceInterface
 
     /**
      * @param Repository $repository
-     * @param string $version
+     * @param String $version
      * @param array $extensions
      * @param array $disabledExtensions
      * @return Repository
      */
     private function addPhp(
         Repository $repository,
-        string $version,
+        String $version,
         array $extensions,
         array $disabledExtensions
     ): Repository {
@@ -218,11 +222,11 @@ class CloudSource implements SourceInterface
 
     /**
      * @param Repository $repository
-     * @param string $version
+     * @param String $version
      * @return Repository
      * @throws SourceException
      */
-    private function addXdebug(Repository $repository, string $version): Repository
+    private function addXdebug(Repository $repository, String $version): Repository
     {
         try {
             $repository->set([
@@ -285,6 +289,20 @@ class CloudSource implements SourceInterface
                 'orig' => $mountData
             ]);
         }
+
+        return $repository;
+    }
+
+    /**
+     * @param Repository $repository
+     * @param String $name
+     * @return Repository
+     */
+    private function addName(Repository $repository, String $name): Repository
+    {
+        $repository->set([
+            "name" => $name,
+        ]);
 
         return $repository;
     }

--- a/src/Config/Source/CloudSource.php
+++ b/src/Config/Source/CloudSource.php
@@ -197,14 +197,14 @@ class CloudSource implements SourceInterface
 
     /**
      * @param Repository $repository
-     * @param String $version
+     * @param string $version
      * @param array $extensions
      * @param array $disabledExtensions
      * @return Repository
      */
     private function addPhp(
         Repository $repository,
-        String $version,
+        string $version,
         array $extensions,
         array $disabledExtensions
     ): Repository {
@@ -226,11 +226,11 @@ class CloudSource implements SourceInterface
 
     /**
      * @param Repository $repository
-     * @param String $version
+     * @param string $version
      * @return Repository
      * @throws SourceException
      */
-    private function addXdebug(Repository $repository, String $version): Repository
+    private function addXdebug(Repository $repository, string $version): Repository
     {
         try {
             $repository->set([
@@ -299,10 +299,10 @@ class CloudSource implements SourceInterface
 
     /**
      * @param Repository $repository
-     * @param String $name
+     * @param string $name
      * @return Repository
      */
-    private function addName(Repository $repository, String $name): Repository
+    private function addName(Repository $repository, string $name): Repository
     {
         $repository->set([
             self::NAME => $name,

--- a/src/Config/Source/CloudSource.php
+++ b/src/Config/Source/CloudSource.php
@@ -132,7 +132,7 @@ class CloudSource implements SourceInterface
         );
         $repository = $this->addName(
             $repository,
-            $appConfig['name'] ?? []
+            $appConfig['name']
         );
 
         return $repository;

--- a/src/Config/Source/CloudSource.php
+++ b/src/Config/Source/CloudSource.php
@@ -89,6 +89,10 @@ class CloudSource implements SourceInterface
             throw new SourceException('Relationships could not be parsed.');
         }
 
+        if (!isset($appConfig['name'])) {
+            throw new SourceException('Name could not be parsed.');
+        }
+
         [$type, $version] = explode(':', $appConfig['type']);
         /**
          * RC versions are not supported

--- a/src/Config/Source/ConfigSource.php
+++ b/src/Config/Source/ConfigSource.php
@@ -50,6 +50,10 @@ class ConfigSource implements SourceInterface
             if ($this->filesystem->exists($configFile)) {
                 $config = Yaml::parseFile($configFile);
 
+                if (!isset($config['name'])) {
+                    throw new SourceException('Name could not be parsed.');
+                }
+
                 /**
                  * Enable services which were added from the file by default
                  */

--- a/src/Config/Source/SourceInterface.php
+++ b/src/Config/Source/SourceInterface.php
@@ -18,6 +18,7 @@ interface SourceInterface
     public const DIR_MAGENTO = '/app';
 
     public const MOUNTS = 'mounts';
+    public const NAME = 'name';
 
     /**
      * Services

--- a/src/Test/Integration/_files/cloud_base/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/cloud_base/docker-compose.exp.yml
@@ -11,10 +11,10 @@ services:
     ports:
       - '3306'
     volumes:
+      - 'docker-mnt:/mnt:delegated'
+      - 'mymagento-mariadb-conf:/etc/mysql/mariadb.conf.d'
       - 'mymagento-magento-db:/var/lib/mysql'
       - 'docker-entrypoint:/docker-entrypoint-initdb.d'
-      - 'mymagento-mariadb-conf:/etc/mysql/mariadb.conf.d'
-      - 'docker-mnt:/mnt:delegated'
     networks:
       magento:
         aliases:
@@ -164,17 +164,6 @@ volumes:
       type: none
       device: '${PWD}/'
       o: bind
-  mymagento-magento-db: {  }
-  mymagento-mariadb-conf:
-    driver_opts:
-      type: none
-      device: '${PWD}/.docker/mysql/mariadb.conf.d'
-      o: bind
-  docker-entrypoint:
-    driver_opts:
-      type: none
-      device: '${PWD}/.docker/mysql/docker-entrypoint-initdb.d'
-      o: bind
   docker-mnt:
     driver_opts:
       type: none
@@ -186,6 +175,17 @@ volumes:
   magento-app-etc: {  }
   magento-pub-media: {  }
   magento-pub-static: {  }
+  mymagento-mariadb-conf:
+    driver_opts:
+      type: none
+      device: '${PWD}/.docker/mysql/mariadb.conf.d'
+      o: bind
+  mymagento-magento-db: {  }
+  docker-entrypoint:
+    driver_opts:
+      type: none
+      device: '${PWD}/.docker/mysql/docker-entrypoint-initdb.d'
+      o: bind
 networks:
   magento:
     driver: bridge

--- a/src/Test/Integration/_files/cloud_base/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/cloud_base/docker-compose.exp.yml
@@ -11,9 +11,9 @@ services:
     ports:
       - '3306'
     volumes:
-      - 'magento-db:/var/lib/mysql'
+      - 'mymagento-magento-db:/var/lib/mysql'
       - 'docker-entrypoint:/docker-entrypoint-initdb.d'
-      - 'mariadb-conf:/etc/mysql/mariadb.conf.d'
+      - 'mymagento-mariadb-conf:/etc/mysql/mariadb.conf.d'
       - 'docker-mnt:/mnt:delegated'
     networks:
       magento:
@@ -164,8 +164,8 @@ volumes:
       type: none
       device: '${PWD}/'
       o: bind
-  magento-db: {  }
-  mariadb-conf:
+  mymagento-magento-db: {  }
+  mymagento-mariadb-conf:
     driver_opts:
       type: none
       device: '${PWD}/.docker/mysql/mariadb.conf.d'

--- a/src/Test/Integration/_files/cloud_base_mftf/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/cloud_base_mftf/docker-compose.exp.yml
@@ -11,10 +11,10 @@ services:
     ports:
       - '3306'
     volumes:
+      - 'docker-mnt:/mnt:delegated'
+      - 'mymagento-mariadb-conf:/etc/mysql/mariadb.conf.d'
       - 'mymagento-magento-db:/var/lib/mysql'
       - 'docker-entrypoint:/docker-entrypoint-initdb.d'
-      - 'mymagento-mariadb-conf:/etc/mysql/mariadb.conf.d'
-      - 'docker-mnt:/mnt:delegated'
     networks:
       magento:
         aliases:
@@ -259,17 +259,6 @@ volumes:
       type: none
       device: '${PWD}/'
       o: bind
-  mymagento-magento-db: {  }
-  mymagento-mariadb-conf:
-    driver_opts:
-      type: none
-      device: '${PWD}/.docker/mysql/mariadb.conf.d'
-      o: bind
-  docker-entrypoint:
-    driver_opts:
-      type: none
-      device: '${PWD}/.docker/mysql/docker-entrypoint-initdb.d'
-      o: bind
   docker-mnt:
     driver_opts:
       type: none
@@ -282,6 +271,17 @@ volumes:
   magento-pub-media: {  }
   magento-pub-static: {  }
   magento-dev: {  }
+  mymagento-mariadb-conf:
+    driver_opts:
+      type: none
+      device: '${PWD}/.docker/mysql/mariadb.conf.d'
+      o: bind
+  mymagento-magento-db: {  }
+  docker-entrypoint:
+    driver_opts:
+      type: none
+      device: '${PWD}/.docker/mysql/docker-entrypoint-initdb.d'
+      o: bind
 networks:
   magento:
     driver: bridge

--- a/src/Test/Integration/_files/cloud_base_mftf/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/cloud_base_mftf/docker-compose.exp.yml
@@ -11,9 +11,9 @@ services:
     ports:
       - '3306'
     volumes:
-      - 'magento-db:/var/lib/mysql'
+      - 'mymagento-magento-db:/var/lib/mysql'
       - 'docker-entrypoint:/docker-entrypoint-initdb.d'
-      - 'mariadb-conf:/etc/mysql/mariadb.conf.d'
+      - 'mymagento-mariadb-conf:/etc/mysql/mariadb.conf.d'
       - 'docker-mnt:/mnt:delegated'
     networks:
       magento:
@@ -259,8 +259,8 @@ volumes:
       type: none
       device: '${PWD}/'
       o: bind
-  magento-db: {  }
-  mariadb-conf:
+  mymagento-magento-db: {  }
+  mymagento-mariadb-conf:
     driver_opts:
       type: none
       device: '${PWD}/.docker/mysql/mariadb.conf.d'


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
https://jira.corp.magento.com/browse/MCLOUD-5859
Currently, the Magento Cloud Docker uses magento-sync volume and other volumes with no prefix for project. This causes collision and conflict when trying to switch projects.

To solve this, it should use a prefix for all volumes, this should probably be from .magento.app.yaml or .magento.docker.yaml and is by default set as follows:name: mymagento

This would then create volumes as mymagento-magento-sync and mymagento-magento-db. This allows projects to set this name and have it generate volumes that can persist.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento-cloud-docker#43: Give us the ability to have multiple projects with different volumes (Prefixed the volume name with the name that is provided in .magento.app.yaml or .magent.docker.yaml)
2. Made Name as a required field. (So that the volumes can prefixed with the given name)

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1) Add .magento.app.yaml or .magento.docker.yaml (with name field included).
2) Run ./vendor/bin/ece-docker build:compose --mode="developer".
3) docker-compose.yaml will be generated.
4) Verify that volume names are prefixed with Name given in .magento.app.yaml or .magento.docker.yaml
5) Verify Multilple projects with different volumes are working.
     
- Mount a project using docker environment
- After that, try to create another one using the same architecture

7) Both projects should work with no error
8) if no Name is provided in .magento.app.yaml or .magento.docker.yaml an  exception will be thrown "Name could not be parsed."

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages

releasenotes
Fixed an issue that can cause volume conflicts when using multiple Docker environments.