### PR TITLE
MCLOUD-3059: [Spike] Investigate issue with elasticsearch image on AWS

### DIFF
--- a/images/elasticsearch/1.7/Dockerfile
+++ b/images/elasticsearch/1.7/Dockerfile
@@ -6,6 +6,6 @@ RUN plugin --install elasticsearch/elasticsearch-analysis-icu/2.7.0 && \
 
 ADD docker-healthcheck.sh /docker-healthcheck.sh
 
-HEALTHCHECK --retries=3 CMD ["sh", "/docker-healthcheck.sh"]
+HEALTHCHECK --retries=3 CMD ["bash", "/docker-healthcheck.sh"]
 
 EXPOSE 9200 9300

--- a/images/elasticsearch/2.4/Dockerfile
+++ b/images/elasticsearch/2.4/Dockerfile
@@ -1,11 +1,14 @@
 FROM elasticsearch:2.4
 
+RUN apt update -y && \
+    apt install procps -y
+
 RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
 RUN bin/plugin install analysis-icu && \
     bin/plugin install analysis-phonetic
 
 ADD docker-healthcheck.sh /docker-healthcheck.sh
 
-HEALTHCHECK --retries=3 CMD ["sh", "/docker-healthcheck.sh"]
+HEALTHCHECK --retries=3 CMD ["bash", "/docker-healthcheck.sh"]
 
 EXPOSE 9200 9300

--- a/images/elasticsearch/5.2/Dockerfile
+++ b/images/elasticsearch/5.2/Dockerfile
@@ -6,6 +6,6 @@ RUN bin/elasticsearch-plugin install analysis-icu && \
 
 ADD docker-healthcheck.sh /docker-healthcheck.sh
 
-HEALTHCHECK --retries=3 CMD ["sh", "/docker-healthcheck.sh"]
+HEALTHCHECK --retries=3 CMD ["bash", "/docker-healthcheck.sh"]
 
 EXPOSE 9200 9300

--- a/images/elasticsearch/6.5/Dockerfile
+++ b/images/elasticsearch/6.5/Dockerfile
@@ -6,6 +6,6 @@ RUN bin/elasticsearch-plugin install analysis-icu && \
 
 ADD docker-healthcheck.sh /docker-healthcheck.sh
 
-HEALTHCHECK --retries=3 CMD ["sh", "/docker-healthcheck.sh"]
+HEALTHCHECK --retries=3 CMD ["bash", "/docker-healthcheck.sh"]
 
 EXPOSE 9200 9300

--- a/images/elasticsearch/7.5/Dockerfile
+++ b/images/elasticsearch/7.5/Dockerfile
@@ -7,6 +7,6 @@ RUN bin/elasticsearch-plugin install -b analysis-icu && \
 
 ADD docker-healthcheck.sh /docker-healthcheck.sh
 
-HEALTHCHECK --retries=3 CMD ["sh", "/docker-healthcheck.sh"]
+HEALTHCHECK --retries=3 CMD ["bash", "/docker-healthcheck.sh"]
 
 EXPOSE 9200 9300

--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -235,6 +235,12 @@ class BuildCompose extends Command
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Port'
+            )
+            ->addOption(
+                Source\CliSource::OPTION_ES_ENVIRONMENT_VARIABLE,
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'Environment variable for elasticsearch service'
             );
 
         parent::configure();

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -13,6 +13,7 @@ use Magento\CloudDocker\Compose\Php\ExtensionResolver;
 use Magento\CloudDocker\Compose\ProductionBuilder\VolumeResolver;
 use Magento\CloudDocker\Config\Config;
 use Magento\CloudDocker\Config\Environment\Converter;
+use Magento\CloudDocker\Config\Source\SourceInterface;
 use Magento\CloudDocker\Filesystem\FileList;
 use Magento\CloudDocker\Service\ServiceFactory;
 use Magento\CloudDocker\Service\ServiceInterface;
@@ -207,6 +208,8 @@ class ProductionBuilder implements BuilderInterface
             $this->addDbService(self::SERVICE_DB_SALES, $manager, $dbVersion, $volumesMount, $config);
         }
 
+        $esEnvVars = $config->get(SourceInterface::SERVICES_ES_VARS);
+
         foreach (self::$standaloneServices as $service) {
             if (!$config->hasServiceEnabled($service)) {
                 continue;
@@ -214,7 +217,13 @@ class ProductionBuilder implements BuilderInterface
 
             $manager->addService(
                 $service,
-                $this->serviceFactory->create((string)$service, (string)$config->getServiceVersion($service)),
+                $this->serviceFactory->create(
+                    (string)$service,
+                    (string)$config->getServiceVersion($service),
+                    self::SERVICE_ELASTICSEARCH === $service && !empty($esEnvVars)
+                        ? ['environment' => $esEnvVars]
+                        : []
+                ),
                 [self::NETWORK_MAGENTO],
                 []
             );

--- a/src/Config/Source/CliSource.php
+++ b/src/Config/Source/CliSource.php
@@ -56,6 +56,11 @@ class CliSource implements SourceInterface
     public const OPTION_PORT = 'port';
 
     /**
+     * Environment variable for elasticsearch service.
+     */
+    public const OPTION_ES_ENVIRONMENT_VARIABLE = 'es-env-var';
+
+    /**
      * Option key to config name map
      *
      * @var array
@@ -110,12 +115,14 @@ class CliSource implements SourceInterface
             ]);
         }
 
-        foreach (self::$optionsMap as $option => $service) {
+        foreach (self::$optionsMap as $option => $services) {
             if ($value = $this->input->getOption($option)) {
-                $repository->set([
-                    $service . '.enabled' => true,
-                    $service . '.version' => $value
-                ]);
+                foreach ($services as $service) {
+                    $repository->set([
+                        $service . '.enabled' => true,
+                        $service . '.version' => $value
+                    ]);
+                }
             }
         }
 
@@ -183,6 +190,10 @@ class CliSource implements SourceInterface
 
         if ($port = $this->input->getOption(self::OPTION_EXPOSE_DB_SALES_PORT)) {
             $repository->set(self::SYSTEM_EXPOSE_DB_SALES_PORTS, $port);
+        }
+
+        if ($esEnvVars = $this->input->getOption(self::OPTION_ES_ENVIRONMENT_VARIABLE)) {
+            $repository->set(self::SERVICES_ES_VARS, $esEnvVars);
         }
 
         return $repository;

--- a/src/Config/Source/SourceInterface.php
+++ b/src/Config/Source/SourceInterface.php
@@ -74,6 +74,11 @@ interface SourceInterface
     public const SERVICES_ES = self::SERVICES . '.' . ServiceInterface::SERVICE_ELASTICSEARCH;
 
     /**
+     * ES environment variables
+     */
+    public const SERVICES_ES_VARS = self::SERVICES_ES.'.'.'env-vars';
+
+    /**
      * Node
      */
     public const SERVICES_NODE = self::SERVICES . '.' . ServiceInterface::SERVICE_NODE;

--- a/src/Test/Functional/Acceptance/ElasticsearchCest.php
+++ b/src/Test/Functional/Acceptance/ElasticsearchCest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CloudDocker\Test\Functional\Acceptance;
+
+use CliTester;
+use Codeception\Example;
+use Robo\Exception\TaskException;
+
+/**
+ * @group php73
+ */
+class ElasticsearchCest extends AbstractAcceptanceCest
+{
+    /**
+     * Template version for testing
+     */
+    protected const TEMPLATE_VERSION = '2.3.3';
+
+    /**
+     * @param CliTester $I
+     * @param Example $data
+     * @dataProvider dataProvider
+     * @return void
+     * @throws TaskException
+     */
+    public function testElasticsearch(CliTester $I, Example $data)
+    {
+        $xms = '512m';
+        $xmx = '512m';
+        $param = 'allow_mmap';
+        $versionsForCheckingParams = ['6.5', '7.5'];
+        $command = sprintf(
+            'build:compose --mode=production --es=%s --es-env-var=ES_JAVA_OPTS="-Xms%s -Xmx%s"',
+            $data['version'],
+            $xms,
+            $xmx
+        );
+        if (in_array($data['version'], $versionsForCheckingParams)) {
+            if ('6.5' === $data['version']) {
+                $param .= 'fs';
+            }
+            $command .= " --es-env-var=node.store.$param=false";
+        }
+        $I->runEceDockerCommand($command);
+        $I->startEnvironment();
+        $I->runDockerComposeCommand('exec -T elasticsearch ps aux | grep elasticsearch');
+        $I->seeInOutput('-Xms' . $xms);
+        $I->seeInOutput('-Xmx' . $xmx);
+
+        if (in_array($data['version'], $versionsForCheckingParams)) {
+            $I->runDockerComposeCommand('exec -T elasticsearch curl http://localhost:9200/_nodes/settings');
+            $I->seeInOutput(sprintf('"store":{"%s":"false"}', $param));
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function dataProvider(): array
+    {
+        return [
+            ['version' => '1.7'],
+            ['version' => '2.4'],
+            ['version' => '5.2'],
+            ['version' => '6.5'],
+            ['version' => '7.5'],
+        ];
+    }
+}

--- a/src/Test/Functional/Acceptance/ElasticsearchCest.php
+++ b/src/Test/Functional/Acceptance/ElasticsearchCest.php
@@ -30,31 +30,25 @@ class ElasticsearchCest extends AbstractAcceptanceCest
      */
     public function testElasticsearch(CliTester $I, Example $data)
     {
-        $xms = '512m';
-        $xmx = '512m';
-        $param = 'allow_mmap';
-        $versionsForCheckingParams = ['6.5', '7.5'];
         $command = sprintf(
             'build:compose --mode=production --es=%s --es-env-var=ES_JAVA_OPTS="-Xms%s -Xmx%s"',
             $data['version'],
-            $xms,
-            $xmx
+            $data['xms'],
+            $data['xmx']
         );
-        if (in_array($data['version'], $versionsForCheckingParams)) {
-            if ('6.5' === $data['version']) {
-                $param .= 'fs';
-            }
-            $command .= " --es-env-var=node.store.$param=false";
+
+        if (!empty($data['param'])) {
+            $command .= " --es-env-var={$data['param']['key']}={$data['param']['value']}";
         }
         $I->runEceDockerCommand($command);
         $I->startEnvironment();
         $I->runDockerComposeCommand('exec -T elasticsearch ps aux | grep elasticsearch');
-        $I->seeInOutput('-Xms' . $xms);
-        $I->seeInOutput('-Xmx' . $xmx);
+        $I->seeInOutput('-Xms' . $data['xms']);
+        $I->seeInOutput('-Xmx' . $data['xmx']);
 
-        if (in_array($data['version'], $versionsForCheckingParams)) {
+        if (!empty($data['param'])) {
             $I->runDockerComposeCommand('exec -T elasticsearch curl http://localhost:9200/_nodes/settings');
-            $I->seeInOutput(sprintf('"store":{"%s":"false"}', $param));
+            $I->seeInOutput($data['param']['needle']);
         }
     }
 
@@ -64,11 +58,46 @@ class ElasticsearchCest extends AbstractAcceptanceCest
     protected function dataProvider(): array
     {
         return [
-            ['version' => '1.7'],
-            ['version' => '2.4'],
-            ['version' => '5.2'],
-            ['version' => '6.5'],
-            ['version' => '7.5'],
+            [
+                'version' => '1.7',
+                'xms' => '512m',
+                'xmx' => '512m',
+            ],
+            [
+                'version' => '2.4',
+                'xms' => '514m',
+                'xmx' => '514m',
+            ],
+            [
+                'version' => '5.2',
+                'xms' => '516m',
+                'xmx' => '516m',
+                'param' => [
+                    'key' => 'index.store.type',
+                    'value' => 'fs',
+                    'needle' => '"index":{"store":{"type":"fs"}}',
+                ]
+            ],
+            [
+                'version' => '6.5',
+                'xms' => '518m',
+                'xmx' => '518m',
+                'param' => [
+                    'key' => 'node.store.allow_mmapfs',
+                    'value' => 'false',
+                    'needle' => '"store":{"allow_mmapfs":"false"}',
+                ]
+            ],
+            [
+                'version' => '7.5',
+                'xms' => '520m',
+                'xmx' => '520m',
+                'param' => [
+                    'key' => 'node.store.allow_mmap',
+                    'value' => 'false',
+                    'needle' => '"store":{"allow_mmap":"false"}',
+                ]
+            ],
         ];
     }
 }


### PR DESCRIPTION
### Description
Added option `--es-env-var` for `docker-compose.yml` file generator. Using this option, you can specify the environment variables that will be applied when starting the Elasticsearch container.
This will allow you to change service settings, such as heap size for JVM or Elasticsearch options.
Parameter changes for JVM are available from image version 1.7
Changing Elasticsearch parameters using environment variables is available starting from version 5.2

### Fixed Issues (if relevant)
1. https://jira.corp.magento.com/browse/MCLOUD-3059

### Manual testing scenarios
1. Clone `[magento-cloud template](https://github.com/magento/magento-cloud)`.
2. Run: `$ composer update` in the magento-cloud template directory: 
3.  Generate the docker-compose.yml file with env variables for `elasticsearch` service: 
```bash
$ php vendor/bin/ece-docker build:compose --es-env-var=ES_JAVA_OPTS="-Xms512m -Xmx512m" --es-env-var=node.store.allow_mmapfs=false
Configuration was built.
```
NOTE: By default, an image with Elasticsearch version 6.5 is used. For this version of Elasticsearch, the option `node.store.allow_mmapfs` exists.
For image varsions 5.2, 2.4, 1.7 ,this option does not exist
Forimage varsions 7.5, this parameter was renamed to node.store.allow_mmap
4. Check the file `docker-compose.yml`, the following settings must exist:
```
... 
elasticsearch:
    hostname: elasticsearch.magento2.docker
    image: 'magento/magento-cloud-docker-elasticsearch:6.5-1.1'
    environment:
      - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
      - node.store.allow_mmapfs=false
    networks:
      magento:
        aliases:
          - elasticsearch.magento2.docker           
....  
```
5. Run: `$ docker-compose up -d`. Containers started successfully
6. Login in elasticsearch container:
```
$ docker-compose exec elasticsearch bash
```
7. Run  the command in the container: `$ ps aux  | grep -E "(Xms|Xmx)"`
Expected: The last values ​​of the `-Xms` and` -Xmx` parameters are 512m

8. Run  the command in the container: ` $ curl http://localhost:9200/_nodes 2>&1 | grep 'mmapfs'`.
Expected:`"allow_mmapfs":"false"` should be present

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages

releasenotes
Added the `docker-compose --es-env-var` option to customize the Elasticsearch container configuration using environment variables, for example setting the heap size for JVM or other Elasticsearch options. See [Elasticsearch container](https://devdocs.magento.com/cloud/docker/docker-containers-service.html#elasticsearch-container).

