### PR TITLE
MCLOUD-5670: Fix for multiple mysql instance error #169

### DIFF
--- a/src/Config/Source/CloudSource.php
+++ b/src/Config/Source/CloudSource.php
@@ -173,7 +173,7 @@ class CloudSource implements SourceInterface
                     continue;
                 }
 
-                if ($repository->has(self::SERVICES . '.' . $service) && $service != "mysql") {
+                if ($repository->has(self::SERVICES . '.' . $service) && $service != ServiceInterface::SERVICE_DB) {
                     throw new SourceException(sprintf(
                         'Only one instance of service "%s" supported',
                         $service

--- a/src/Config/Source/CloudSource.php
+++ b/src/Config/Source/CloudSource.php
@@ -173,7 +173,7 @@ class CloudSource implements SourceInterface
                     continue;
                 }
 
-                if ($repository->has(self::SERVICES . '.' . $service)) {
+                if ($repository->has(self::SERVICES . '.' . $service) && $service != "mysql") {
                     throw new SourceException(sprintf(
                         'Only one instance of service "%s" supported',
                         $service


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
 Include an option to add multiple MySQL users.

At this moment, When multiple MySQL users are added, The docker-compose fails with the below error:-
```
In Config.php line 96:                                                  
  Only one instance of service "mysql" supported  
                                                  
In Reader.php line 90:
  Only one instance of service "mysql" supported 
```
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. [MCLOUD-5670](https://jira.corp.magento.com/browse/MCLOUD-5670): magento/magento-cloud-docker#169: Docker compose fails if multiple users for mysql configured

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.Add Multiple mysql users in services.yml, as described here https://devdocs.magento.com/cloud/project/project-conf-files_services-mysql.html
```
mysql:
    type: mysql:10.2
    disk: 2048
    configuration:
        schemas:
            - main
        endpoints:
            admin:
                default_schema: main
                privileges:
                    main: admin
            reporter:
                privileges:
                    main: ro

redis:
    type: redis:5.0

elasticsearch:
    type: elasticsearch:6.5
    disk: 1024
```
2.Add the endpoints defined, to the relationships property of the .magento.app.yaml file. 
```
relationships:
    database: "mysql:admin"
    databasereporter: "mysql:reporter"
```
3. Run ./vendor/bin/ece-docker build:compose --mode="developer"

**Expected result**
Docker build is successful


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
