### PR TITLE
MCLOUD-5586: Upgrade Node.js in the PHP container

### DIFF
--- a/images/php/7.1-cli/Dockerfile
+++ b/images/php/7.1-cli/Dockerfile
@@ -12,7 +12,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mcrypt mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Configure Node.js version
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 
 # Install dependencies
 RUN apt-get update \

--- a/images/php/7.2-cli/Dockerfile
+++ b/images/php/7.2-cli/Dockerfile
@@ -12,7 +12,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Configure Node.js version
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 
 # Install dependencies
 RUN apt-get update \

--- a/images/php/7.3-cli/Dockerfile
+++ b/images/php/7.3-cli/Dockerfile
@@ -12,7 +12,7 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
 # Configure Node.js version
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 
 # Install dependencies
 RUN apt-get update \


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->
[**MCLOUD-5586**](https://jira.corp.magento.com/browse/MCLOUD-5586): Upgrade Node.js in the PHP container
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Magneto Cloud Docker includes a Node.js installation as part of the CLI containers. This can be seen here: https://github.com/magento/magento-cloud-docker/blob/develop/images/php/cli/Dockerfile#L15

However, the problem is that it installs Node.js 8, which no longer receives security updates according to https://nodejs.org/en/about/releases/

So I have updated the Node.js version to 10

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento-cloud-docker#172: Upgrade Node.js in the PHP container

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run docker-compose run deploy node -v from your project folder.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages