### PR TITLE
MCLOUD-5797: Fix for compose build failing if Blackfire configuration present

### DIFF
--- a/src/Compose/Php/ExtensionResolver.php
+++ b/src/Compose/Php/ExtensionResolver.php
@@ -110,8 +110,12 @@ class ExtensionResolver
     public function get(Config $config): array
     {
         $phpVersion = $config->getServiceVersion(ServiceInterface::SERVICE_PHP);
+        $enabledPhpExtensions = [];
+        foreach ($config->getEnabledPhpExtensions() as $phpExtension) {
+            is_array($phpExtension) ? : array_push($enabledPhpExtensions, $phpExtension);
+        }
         $enabledExtensions = array_unique(
-            array_merge(self::DEFAULT_PHP_EXTENSIONS, $config->getEnabledPhpExtensions())
+            array_merge(self::DEFAULT_PHP_EXTENSIONS, $enabledPhpExtensions)
         );
         $phpExtensions = array_diff(
             $enabledExtensions,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
[MCLOUD-5797](https://jira.corp.magento.com/browse/MCLOUD-5797): Fixed Compose build is failing if Blackfire configuration present issue


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento-cloud-docker#146: Compose build is failing if Blackfire configuration present 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Have the next config in .magento.app.yaml:
```
runtime:
    extensions:
        - redis
        - xsl
        - json
        - blackfire
        - newrelic
        - sodium
        -
            name: "blackfire"
            configuration:
                server_id: ""
                server_token: ""
```
2.Run  ``` ./vendor/bin/ece-docker build:compose ```

**Expected result**
Docker build is successful




### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
