### PR TITLE
MCLOUD-5735: Add support for auto_increment option #195

### DIFF
--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -226,6 +226,16 @@ class BuildCompose extends Command
             null,
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Environment variable for elasticsearch service'
+        )->addOption(
+            Source\CliSource::OPTION_DB_INCREMENT_INCREMENT,
+            null,
+            InputOption::VALUE_REQUIRED,
+            '"auto_increment_increment" database variable'
+        )->addOption(
+            Source\CliSource::OPTION_DB_INCREMENT_OFFSET,
+            null,
+            InputOption::VALUE_REQUIRED,
+            '"auto_increment_offset" database variable'
         );
 
         parent::configure();

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -464,6 +464,7 @@ class ProductionBuilder implements BuilderInterface
     ): void {
         $volumePrefix = $config->getNameWithPrefix();
         $mounts[] = $volumePrefix . self::VOLUME_MARIADB_CONF . ':/etc/mysql/mariadb.conf.d';
+        $commands = [];
 
         switch ($service) {
             case self::SERVICE_DB:
@@ -478,6 +479,15 @@ class ProductionBuilder implements BuilderInterface
                 $mounts[] = $volumePrefix . self::VOLUME_MAGENTO_DB . ':/var/lib/mysql';
                 $mounts[] = self::VOLUME_DOCKER_ETRYPOINT . ':/docker-entrypoint-initdb.d';
                 $serviceType = ServiceInterface::SERVICE_DB;
+
+                if ($config->getDbIncrementIncrement() > 1) {
+                    $commands[] = '--auto_increment_increment=' . $config->getDbIncrementIncrement();
+                }
+
+                if ($config->getDbIncrementOffset() > 1) {
+                    $commands[] = '--auto_increment_offset=' . $config->getDbIncrementOffset();
+                }
+
                 break;
             case self::SERVICE_DB_QUOTE:
                 $port = $config->getDbQuotePortsExpose();
@@ -511,15 +521,21 @@ class ProductionBuilder implements BuilderInterface
                 throw new GenericException(sprintf('Configuration for %s service not exist', $service));
         }
 
+        $dbConfig = [
+            'ports' => [$port ? "$port:3306" : '3306'],
+            'volumes' => $mounts,
+        ];
+
+        if ($commands) {
+            $dbConfig['command'] = implode(' ', $commands);
+        }
+
         $manager->addService(
             $service,
             $this->serviceFactory->create(
                 $serviceType,
                 $version,
-                [
-                    'ports' => [$port ? "$port:3306" : '3306'],
-                    'volumes' => $mounts,
-                ]
+                $dbConfig
             ),
             [self::NETWORK_MAGENTO],
             []

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -395,7 +395,10 @@ class Config
      */
     public function getDbIncrementIncrement(): int
     {
-        return (int)$this->all()->get(SourceInterface::SYSTEM_DB_INCREMENT_INCREMENT, 1);
+        return max(
+            (int)$this->all()->get(SourceInterface::SYSTEM_DB_INCREMENT_INCREMENT, 1),
+            1
+        );
     }
 
     /**
@@ -404,6 +407,9 @@ class Config
      */
     public function getDbIncrementOffset(): int
     {
-        return (int)$this->all()->get(SourceInterface::SYSTEM_DB_INCREMENT_OFFSET, 1);
+        return max(
+            (int)$this->all()->get(SourceInterface::SYSTEM_DB_INCREMENT_OFFSET, 1),
+            1
+        );
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -388,4 +388,22 @@ class Config
     {
         return $this->all()->get(SourceInterface::MAGENTO_VERSION);
     }
+
+    /**
+     * @return int
+     * @throws ConfigurationMismatchException
+     */
+    public function getDbIncrementIncrement(): int
+    {
+        return (int)$this->all()->get(SourceInterface::SYSTEM_DB_INCREMENT_INCREMENT, 1);
+    }
+
+    /**
+     * @return int
+     * @throws ConfigurationMismatchException
+     */
+    public function getDbIncrementOffset(): int
+    {
+        return (int)$this->all()->get(SourceInterface::SYSTEM_DB_INCREMENT_OFFSET, 1);
+    }
 }

--- a/src/Config/Source/CliSource.php
+++ b/src/Config/Source/CliSource.php
@@ -55,6 +55,9 @@ class CliSource implements SourceInterface
     public const OPTION_HOST = 'host';
     public const OPTION_PORT = 'port';
 
+    public const OPTION_DB_INCREMENT_INCREMENT = 'db-increment-increment';
+    public const OPTION_DB_INCREMENT_OFFSET = 'db-increment-offset';
+
     /**
      * Environment variable for elasticsearch service.
      */
@@ -211,6 +214,14 @@ class CliSource implements SourceInterface
 
         if ($esEnvVars = $this->input->getOption(self::OPTION_ES_ENVIRONMENT_VARIABLE)) {
             $repository->set(self::SERVICES_ES_VARS, $esEnvVars);
+        }
+
+        if ($incrementIncrement = $this->input->getOption(self::OPTION_DB_INCREMENT_INCREMENT)) {
+            $repository->set(SourceInterface::SYSTEM_DB_INCREMENT_INCREMENT, $incrementIncrement);
+        }
+
+        if ($incrementOffset = $this->input->getOption(self::OPTION_DB_INCREMENT_OFFSET)) {
+            $repository->set(SourceInterface::SYSTEM_DB_INCREMENT_OFFSET, $incrementOffset);
         }
 
         return $repository;

--- a/src/Config/Source/SourceInterface.php
+++ b/src/Config/Source/SourceInterface.php
@@ -120,6 +120,9 @@ interface SourceInterface
     public const SYSTEM_EXPOSE_DB_QUOTE_PORTS = 'system.expose_db_quote_ports';
     public const SYSTEM_EXPOSE_DB_SALES_PORTS = 'system.expose_db_sales_ports';
 
+    public const SYSTEM_DB_INCREMENT_INCREMENT = 'system.db.increment_increment';
+    public const SYSTEM_DB_INCREMENT_OFFSET = 'system.db.increment_offset';
+
     public const VARIABLES = 'variables';
 
     public const HOOKS = 'hooks';

--- a/src/Test/Integration/BuildComposeTest.php
+++ b/src/Test/Integration/BuildComposeTest.php
@@ -85,7 +85,9 @@ class BuildComposeTest extends TestCase
                     [CliSource::OPTION_WITH_CRON, true],
                     [CliSource::OPTION_WITH_XDEBUG, true],
                     [CliSource::OPTION_ES, '5.2'],
-                    [CliSource::OPTION_NO_ES, true]
+                    [CliSource::OPTION_NO_ES, true],
+                    [CliSource::OPTION_DB_INCREMENT_INCREMENT, 3],
+                    [CliSource::OPTION_DB_INCREMENT_OFFSET, 2],
                 ]
             ]
         ];

--- a/src/Test/Integration/BuildCustomComposeTest.php
+++ b/src/Test/Integration/BuildCustomComposeTest.php
@@ -81,7 +81,11 @@ class BuildCustomComposeTest extends TestCase
                             'system' => [
                                 'mode' => 'production',
                                 'host' => 'magento2.test',
-                                'port' => '8080'
+                                'port' => '8080',
+                                'db' => [
+                                    'increment_increment' => 3,
+                                    'increment_offset' => 2
+                                ]
                             ],
                             'services' => [
                                 'php' => [
@@ -97,9 +101,9 @@ class BuildCustomComposeTest extends TestCase
                                 ],
                             ],
                             'hooks' => [
-                                'build' => 'set -e
-php ./vendor/bin/ece-tools run scenario/build/generate.xml
-php ./vendor/bin/ece-tools run scenario/build/transfer.xml',
+                                'build' => 'set -e' . PHP_EOL
+                                    . 'php ./vendor/bin/ece-tools run scenario/build/generate.xml' . PHP_EOL
+                                    . 'php ./vendor/bin/ece-tools run scenario/build/transfer.xml',
                                 'deploy' => 'php ./vendor/bin/ece-tools run scenario/deploy.xml',
                                 'post_deploy' => 'php ./vendor/bin/ece-tools run scenario/post-deploy.xml'
                             ],

--- a/src/Test/Integration/_files/cloud_base_mftf/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/cloud_base_mftf/docker-compose.exp.yml
@@ -15,6 +15,7 @@ services:
       - 'mymagento-mariadb-conf:/etc/mysql/mariadb.conf.d'
       - 'mymagento-magento-db:/var/lib/mysql'
       - 'docker-entrypoint:/docker-entrypoint-initdb.d'
+    command: '--auto_increment_increment=3 --auto_increment_offset=2'
     networks:
       magento:
         aliases:

--- a/src/Test/Integration/_files/custom_cloud_base/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/custom_cloud_base/docker-compose.exp.yml
@@ -15,6 +15,7 @@ services:
       - 'magento-mariadb-conf:/etc/mysql/mariadb.conf.d'
       - 'magento-magento-db:/var/lib/mysql'
       - 'docker-entrypoint:/docker-entrypoint-initdb.d'
+    command: '--auto_increment_increment=3 --auto_increment_offset=2'
     networks:
       magento:
         aliases:


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Since Magento Cloud Pro has multi-cluster setup, Cloud Docker should be able to provide similar conditions like auto_increment option (default is 1)

https://dev.mysql.com/doc/refman/8.0/en/example-auto-increment.html

* Add functionality and documentation on how to change the MySQL settings including the auto_increment option
* Add the option to Docker Builder

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #195 
2. https://jira.corp.magento.com/browse/MCLOUD-5735

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run
```
./bin/dev-ece-docker build:compose
```
1. Deploy Magento
2. Connect to DB and verify there are no gaps in `core_config_data` table:
```
SELECT * FROM core_config_data\G`
```
3. Run 
```
./bin/dev-ece-docker build:compose --db-increment-increment 3 --db-increment-offset 2
```
4. Connect to DB and verify there are 2 indexes gaps in `core_config_data` table:
```
SELECT * FROM core_config_data\G`
```
### Release notes

* Added the ability to customize MySQL auto-increment settings when you generate the Docker compose file.

### Associated documentation updates

https://github.com/magento/devdocs/pull/7356


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
