### PR TITLE
MCLOUD-6008: Include ssh client to make use of ssh-agent forwarding for composer

### DIFF
--- a/dist/bin/magento-docker
+++ b/dist/bin/magento-docker
@@ -85,7 +85,15 @@ case "$1" in
     php)
         version="$2"
         shift 2
-        docker run --rm -it -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache "magento/magento-cloud-docker-php:${version}-cli" "$@"
+        # allow ssh-agent forwarding for composer.json files that need access to private repos
+        if [[ $(uname) = Darwin ]]; then
+            # https://docs.docker.com/docker-for-mac/osxfs/#ssh-agent-forwarding (D4M > 2.2)
+            SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"
+        fi
+        docker run --rm -it -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache \
+            --mount "type=bind,src=$HOME/.ssh/known_hosts,target=/root/.ssh/known_hosts" \
+            --mount "type=bind,src=$SSH_AUTH_SOCK,target=$SSH_AUTH_SOCK" -e SSH_AUTH_SOCK="$SSH_AUTH_SOCK" \
+            "magento/magento-cloud-docker-php:${version}-cli-1.1" "$@"
         ;;
     *)
         printf "$USAGE"

--- a/dist/bin/magento-docker
+++ b/dist/bin/magento-docker
@@ -88,7 +88,7 @@ case "$1" in
         # allow ssh-agent forwarding for composer.json files that need access to private repos
         if [[ $(uname) = Darwin ]]; then
             # https://docs.docker.com/docker-for-mac/osxfs/#ssh-agent-forwarding (D4M > 2.2)
-            SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"
+            export SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"
         fi
         docker run --rm -it -e "MAGENTO_ROOT=/app" -v "$(pwd)":/app -v ~/.composer/cache:/root/.composer/cache \
             --mount "type=bind,src=$HOME/.ssh/known_hosts,target=/root/.ssh/known_hosts" \

--- a/images/php/7.2-cli/Dockerfile
+++ b/images/php/7.2-cli/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
   sudo \
   unzip \
   vim \
+  openssh-client \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \

--- a/images/php/7.3-cli/Dockerfile
+++ b/images/php/7.3-cli/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
   sudo \
   unzip \
   vim \
+  openssh-client \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \

--- a/images/php/7.4-cli/Dockerfile
+++ b/images/php/7.4-cli/Dockerfile
@@ -2,6 +2,7 @@
 FROM php:7.4-cli-buster
 ARG GOSU_VERSION=1.11
 
+ENV COMPOSER_MEMORY_LIMIT -1
 ENV PHP_MEMORY_LIMIT 2G
 ENV MAGENTO_ROOT /app
 ENV DEBUG false
@@ -33,6 +34,7 @@ RUN apt-get update \
   sudo \
   unzip \
   vim \
+  openssh-client \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \

--- a/src/Command/Image/GeneratePhp.php
+++ b/src/Command/Image/GeneratePhp.php
@@ -53,6 +53,7 @@ class GeneratePhp extends Command
         'sudo',
         'unzip',
         'vim',
+        'openssh-client',
     ];
 
     private const PHP_EXTENSIONS_ENABLED_BY_DEFAULT = [


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
https://jira.corp.magento.com/browse/MCLOUD-6008
This PR build off of https://github.com/magento/magento-cloud-docker/pull/209.
Many composer.json files include private git repos that need an ssh client included for various composer commands. This PR includes the ssh client and enables the local ssh-agent so composer commands work as expected.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. push the new images with the ssh client to the docker hub
2. verify access:
`./magento-docker php 7.3 ssh -T git@github.com`
You should see:
`Hi <GITHUBUSERNAME>! You've successfully authenticated, but GitHub does not provide shell access.`
3. run `composer install` with a private repo that the container would not normally have access to but the credentials are available in your ssh-agent.

### Release notes

That sub-command exists so users can run composer install independent of their local php version as may be required by the composer.json that they want to install.

Also supports private repos cloned over ssh using your ssh-agent.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
