### PR TITLE
MCLOUD-6043 Fix replace variable WITH_XDEBUG in nginx configuration

### DIFF
--- a/images/nginx/1.9/docker-entrypoint.sh
+++ b/images/nginx/1.9/docker-entrypoint.sh
@@ -14,6 +14,7 @@ XDEBUG_UPSTREAM_FILE="/etc/nginx/conf.d/xdebug/upstream.conf"
 [ ! -z "${MAGENTO_RUN_MODE}" ] && sed -i "s/!MAGENTO_RUN_MODE!/${MAGENTO_RUN_MODE}/" $VHOST_FILE
 [ ! -z "${MFTF_UTILS}" ] && sed -i "s/!MFTF_UTILS!/${MFTF_UTILS}/" $VHOST_FILE
 [ ! -z "${UPLOAD_MAX_FILESIZE}" ] && sed -i "s/!UPLOAD_MAX_FILESIZE!/${UPLOAD_MAX_FILESIZE}/" $VHOST_FILE
+[ ! -z "${WITH_XDEBUG}" ] && sed -i "s/!WITH_XDEBUG!/${WITH_XDEBUG}/" $VHOST_FILE
 [ "${WITH_XDEBUG}" == "1" ] && sed -i "s/#include_xdebug_upstream/include/" $NGINX_FILE
 
 # Check if the nginx syntax is fine, then launch.

--- a/images/nginx/1.9/etc/vhost.conf
+++ b/images/nginx/1.9/etc/vhost.conf
@@ -11,7 +11,7 @@ server {
     set $MAGE_ROOT !MAGENTO_ROOT!; # Variable: MAGENTO_ROOT
     set $MAGE_MODE !MAGENTO_RUN_MODE!; # Variable: MAGENTO_RUN_MODE
     set $MFTF_UTILS !MFTF_UTILS!; # Variable: MFTF_UTILS
-    set $WITH_XDEBUG !$WITH_XDEBUG!; # Variable: WITH_XDEBUG
+    set $WITH_XDEBUG !WITH_XDEBUG!; # Variable: WITH_XDEBUG
 
     set $my_fastcgi_pass "fastcgi_backend";
     if ($cookie_XDEBUG_SESSION) {


### PR DESCRIPTION
The WITH_XDEBUG variable is not set correctly in default.conf of nginx.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages

https://jira.corp.magento.com/browse/MCLOUD-6043