### PR TITLE
MCLOUD-6086: Add PHP 7.4 to magento-cloud-docker tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ jobs:
       php: '7.3'
       env:
         - TEST_SUITE=static-unit
+    - script: ./tests/travis/static-unit.sh;
+      php: '7.4'
+      env:
+        - TEST_SUITE=static-unit
     - stage: integration
       script: ./vendor/bin/phpunit --configuration ./tests/integration;
       php: '7.2'
@@ -38,6 +42,10 @@ jobs:
         - TEST_SUITE=integration
     - script: ./vendor/bin/phpunit --configuration ./tests/integration;
       php: '7.3'
+      env:
+        - TEST_SUITE=integration
+    - script: ./vendor/bin/phpunit --configuration ./tests/integration;
+      php: '7.4'
       env:
         - TEST_SUITE=integration
     - stage: build-images
@@ -56,6 +64,11 @@ jobs:
     - script:
         - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then ./tests/travis/images.sh php 7.3-cli; fi;
         - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then ./tests/travis/images.sh php 7.3-fpm; fi;
+      env:
+        - TEST_SUITE=build-images
+    - script:
+        - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then ./tests/travis/images.sh php 7.4-cli; fi;
+        - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then ./tests/travis/images.sh php 7.4-fpm; fi;
       env:
         - TEST_SUITE=build-images
     - stage: test


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
After adding the image php-7.4-cli and php-7.4-fpm we need to add tests with this PHP version.

Currently we can add only:

- unit/static tests 
- integration tests
- image building
 

Function Tests currently we cannot add because we need the released Magento which support PHP 7.4
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/ece-tools#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://jira.corp.magento.com/browse/MCLOUD-6086

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
No need for manual testing.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
