### PR TITLE
MCLOUD-6294: If Mysql set as DB docker set up 3 split DB by default

### DIFF
--- a/src/Config/Source/CliSource.php
+++ b/src/Config/Source/CliSource.php
@@ -132,7 +132,6 @@ class CliSource implements SourceInterface
             if ($value = $this->input->getOption($option)) {
                 foreach ($services as $service) {
                     $repository->set([
-                        $service . '.enabled' => true,
                         $service . '.version' => $value
                     ]);
                 }

--- a/src/Config/Source/CliSource.php
+++ b/src/Config/Source/CliSource.php
@@ -70,17 +70,29 @@ class CliSource implements SourceInterface
      * @var array
      */
     private static $enableOptionsMap = [
-        self::OPTION_PHP => [self::PHP],
-        self::OPTION_DB => [
-            self::SERVICES_DB,
-            self::SERVICES_DB_QUOTE,
-            self::SERVICES_DB_SALES
+        self::OPTION_PHP => [
+            self::PHP => true
         ],
-        self::OPTION_NGINX => [self::SERVICES_NGINX],
-        self::OPTION_REDIS => [self::SERVICES_REDIS],
-        self::OPTION_ES => [self::SERVICES_ES],
-        self::OPTION_NODE => [self::SERVICES_NODE],
-        self::OPTION_RABBIT_MQ => [self::SERVICES_RMQ],
+        self::OPTION_DB => [
+            self::SERVICES_DB => true,
+            self::SERVICES_DB_QUOTE => false,
+            self::SERVICES_DB_SALES => false
+        ],
+        self::OPTION_NGINX => [
+            self::SERVICES_NGINX => true
+        ],
+        self::OPTION_REDIS => [
+            self::SERVICES_REDIS => true
+        ],
+        self::OPTION_ES => [
+            self::SERVICES_ES => true
+        ],
+        self::OPTION_NODE => [
+            self::SERVICES_NODE => true
+        ],
+        self::OPTION_RABBIT_MQ => [
+            self::SERVICES_RMQ => true
+        ],
     ];
 
     /**
@@ -128,12 +140,25 @@ class CliSource implements SourceInterface
             ]);
         }
 
+        /**
+         * Loop through options to enable services.
+         * Each option may have one or more dependencies.
+         *
+         * The dependencies must be in sync.
+         * The dependencies which does not change status, must keep their default status.
+         */
         foreach (self::$enableOptionsMap as $option => $services) {
             if ($value = $this->input->getOption($option)) {
-                foreach ($services as $service) {
+                foreach ($services as $service => $status) {
                     $repository->set([
                         $service . '.version' => $value
                     ]);
+
+                    if ($status === true) {
+                        $repository->set([
+                            $service . '.enabled' => true
+                        ]);
+                    }
                 }
             }
         }

--- a/src/Test/Unit/Config/Dist/GeneratorTest.php
+++ b/src/Test/Unit/Config/Dist/GeneratorTest.php
@@ -109,7 +109,7 @@ class GeneratorTest extends TestCase
             ->willReturn('magento2.docker');
         $config->expects($this->once())
             ->method('getPort')
-            ->willReturn(80);
+            ->willReturn('80');
         $this->envReaderMock->expects($this->once())
             ->method('read')
             ->willReturn([]);


### PR DESCRIPTION
https://jira.corp.magento.com/browse/MCLOUD-6294

### Description

> Recently we added Mysql as alternative DB instead of MariaDB. If Mysql set as DB docker set up 3 split DB by default:
> 
> ```bash
> magento-cloud_db-quote_1        docker-entrypoint.sh mysqld      Up (healthy)   0.0.0.0:32813->3306/tcp
> magento-cloud_db-sales_1        docker-entrypoint.sh mysqld      Up (healthy)   0.0.0.0:32815->3306/tcp
> magento-cloud_db_1              docker-entrypoint.sh mysqld      Up (healthy)   0.0.0.0:32814->3306/tcp
> ```
> 
> *Step to reproduce:*
> 
> ```bash
> build:compose --db 5.6 --db-image mysql
> docker-compose up
> docker-compose ps
> ```

### Fixed Issues (if relevant)
https://jira.corp.magento.com/browse/MCLOUD-6294

### Manual testing scenarios
1. Build `docker-compose.yaml` file:
`$ php vendor/bin/ece-docker build:compose --db <version>`
2. Check `docker-compose.yaml` file.  Services `db-quote` and `db-sales` do not exist.
3. Run `docker-compose up -d`. All services started successfully.
4. Take the tests published in the following  PRs:
  - https://github.com/magento/magento-cloud-docker/pull/161
  - https://github.com/magento/magento-cloud-docker/pull/206

### Release notes

For user-facing changes, add a meaningful release note. For examples, see [Magento Cloud Docker release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).

### Associated documentation updates
<!--
 If your proposed update requires user documentation, submit a PR to the Magento DevDocs repository. For extensive updates requiring assistance, submit an issue to DevDocs. See https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md.
 -->
Add link to Magento DevDocs PR or Issue, if needed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [ ] All commits are accompanied by meaningful commit messages
