### PR TITLE
MCLOUD-6621: ps library is missing on newer images

### DIFF
--- a/images/php/7.1-cli/Dockerfile
+++ b/images/php/7.1-cli/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update \
   python3 \
   python3-pip \
   redis-tools \
+  sendmail-bin \
+  sendmail \
   sudo \
   unzip \
   vim \

--- a/images/php/7.1-fpm/Dockerfile
+++ b/images/php/7.1-fpm/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
   apt-utils \
+  sendmail-bin \
+  sendmail \
   sudo \
   libbz2-dev \
   libjpeg62-turbo-dev \

--- a/images/php/7.2-cli/Dockerfile
+++ b/images/php/7.2-cli/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update \
   python3 \
   python3-pip \
   redis-tools \
+  sendmail-bin \
+  sendmail \
   sudo \
   unzip \
   vim \

--- a/images/php/7.2-fpm/Dockerfile
+++ b/images/php/7.2-fpm/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
   apt-utils \
+  sendmail-bin \
+  sendmail \
   sudo \
   libbz2-dev \
   libjpeg62-turbo-dev \

--- a/images/php/7.3-cli/Dockerfile
+++ b/images/php/7.3-cli/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update \
   python3 \
   python3-pip \
   redis-tools \
+  sendmail-bin \
+  sendmail \
   sudo \
   unzip \
   vim \

--- a/images/php/7.3-fpm/Dockerfile
+++ b/images/php/7.3-fpm/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
   apt-utils \
+  sendmail-bin \
+  sendmail \
   sudo \
   libbz2-dev \
   libjpeg62-turbo-dev \

--- a/images/php/7.4-cli/Dockerfile
+++ b/images/php/7.4-cli/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update \
   python3 \
   python3-pip \
   redis-tools \
+  sendmail-bin \
+  sendmail \
   sudo \
   unzip \
   vim \

--- a/images/php/7.4-fpm/Dockerfile
+++ b/images/php/7.4-fpm/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
   apt-utils \
+  sendmail-bin \
+  sendmail \
   sudo \
   libbz2-dev \
   libjpeg62-turbo-dev \

--- a/src/Command/Image/GeneratePhp.php
+++ b/src/Command/Image/GeneratePhp.php
@@ -33,6 +33,8 @@ class GeneratePhp extends Command
     private const ARGUMENT_VERSION = 'version';
     private const DEFAULT_PACKAGES_PHP_FPM = [
         'apt-utils',
+        'sendmail-bin',
+        'sendmail',
         'sudo'
     ];
     private const DEFAULT_PACKAGES_PHP_CLI = [
@@ -45,6 +47,8 @@ class GeneratePhp extends Command
         'python3',
         'python3-pip',
         'redis-tools',
+        'sendmail-bin',
+        'sendmail',
         'sudo',
         'unzip',
         'vim',


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR revert Sendmail packages which had ps library installed


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-docker#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento-cloud-docker/issues/259

### Release notes

For user-facing changes, add a meaningful release note. For examples, see [Magento Cloud Docker release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).

### Associated documentation updates
<!--
 If your proposed update requires user documentation, submit a PR to the Magento DevDocs repository. For extensive updates requiring assistance, submit an issue to DevDocs. See https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md.
 -->
Add link to Magento DevDocs PR or Issue, if needed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [ ] All commits are accompanied by meaningful commit messages
