### PR TITLE
MCLOUD-6469: dh key too small when trying to use magento-cloud-docker-tls

### DIFF
--- a/images/php/7.2-fpm/Dockerfile
+++ b/images/php/7.2-fpm/Dockerfile
@@ -51,6 +51,8 @@ RUN wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendma
     && sudo chmod +x mhsendmail_linux_amd64 \
     && sudo mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail
 
+RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
+
 # Configure the gd library
 RUN docker-php-ext-configure \
   gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/

--- a/images/php/7.2-fpm/Dockerfile
+++ b/images/php/7.2-fpm/Dockerfile
@@ -51,6 +51,7 @@ RUN wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendma
     && sudo chmod +x mhsendmail_linux_amd64 \
     && sudo mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail
 
+# Change security level to avoid `dh key too small` error
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
 
 # Configure the gd library

--- a/images/php/7.3-fpm/Dockerfile
+++ b/images/php/7.3-fpm/Dockerfile
@@ -49,6 +49,8 @@ RUN wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendma
     && sudo chmod +x mhsendmail_linux_amd64 \
     && sudo mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail
 
+RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
+
 # Configure the gd library
 RUN docker-php-ext-configure \
   gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/

--- a/images/php/7.3-fpm/Dockerfile
+++ b/images/php/7.3-fpm/Dockerfile
@@ -49,6 +49,7 @@ RUN wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendma
     && sudo chmod +x mhsendmail_linux_amd64 \
     && sudo mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail
 
+# Change security level to avoid `dh key too small` error
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
 
 # Configure the gd library

--- a/images/php/7.4-fpm/Dockerfile
+++ b/images/php/7.4-fpm/Dockerfile
@@ -45,6 +45,7 @@ RUN wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendma
     && sudo chmod +x mhsendmail_linux_amd64 \
     && sudo mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail
 
+# Change security level to avoid `dh key too small` error
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
 
 # Configure the gd library

--- a/images/php/7.4-fpm/Dockerfile
+++ b/images/php/7.4-fpm/Dockerfile
@@ -45,6 +45,8 @@ RUN wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendma
     && sudo chmod +x mhsendmail_linux_amd64 \
     && sudo mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail
 
+RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
+
 # Configure the gd library
 RUN docker-php-ext-configure \
   gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -24,6 +24,8 @@ RUN wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendma
     && sudo chmod +x mhsendmail_linux_amd64 \
     && sudo mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail
 
+RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
+
 # Configure the gd library
 {%docker-php-ext-configure%}
 

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -24,6 +24,7 @@ RUN wget https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendma
     && sudo chmod +x mhsendmail_linux_amd64 \
     && sudo mv mhsendmail_linux_amd64 /usr/local/bin/mhsendmail
 
+# Change security level to avoid `dh key too small` error
 RUN sed -i 's/SECLEVEL=2/SECLEVEL=1/g' /etc/ssl/openssl.cnf
 
 # Configure the gd library


### PR DESCRIPTION
### Description

Changed security level in `/etc/ssl/openssl.cnf` to avoid `dh key too small` error

### Fixed Issues (if relevant)

https://jira.corp.magento.com/browse/MCLOUD-6469

### Manual testing scenarios

1. Install magento 2.4.0 in docker
2. Connect to fpm container:
`docker exec -it magento-cloud_fpm_1 bash`
3. Run command
`curl -k https://tls.magento2.docker/` will return an error `dh key too small`
4. Run `docker-compose down -v`
5. Build php fpm image from branch
`docker build -t magento-cloud-docker-php-fpm-6469 images/php/7.4-fpm`
6. Change `docker-compose.yaml` file
```yaml
  fpm:
    hostname: fpm.magento2.docker
    image: 'magento-cloud-docker-php-fpm-6469'
``` 
7. Run `docker-compose up -d` 
`docker-compose run build cloud-build`
`docker-compose run deploy cloud-deploy`
`docker-compose run deploy cloud-post-deploy`
8. Connect to fpm container:
`docker exec -it magento-cloud_fpm_1 bash`
9. Run command
`curl -k https://tls.magento2.docker/` command run without error

### Release notes

Changed the security level in the OpenSSL configuration file (`/etc/ssl/openssl.cnf`) to fix a `dh key too small` error that occurs on TLS connection requests in the Cloud Docker environment.

### Associated documentation updates

Not required.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [ ] All commits are accompanied by meaningful commit messages
