### PR TITLE
MCLOUD-6219: Add ES 7.7 image to docker 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,11 @@ jobs:
         - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then ./tests/travis/images.sh php 7.3-fpm; fi;
       env:
         - TEST_SUITE=build-images
+    - script:
+        - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then ./tests/travis/images.sh php 7.4-cli; fi;
+        - if [ $TRAVIS_SECURE_ENV_VARS == "true" ]; then ./tests/travis/images.sh php 7.4-fpm; fi;
+      env:
+        - TEST_SUITE=build-images
     - stage: test
       php: '7.1'
       dist: xenial

--- a/images/elasticsearch/7.7/Dockerfile
+++ b/images/elasticsearch/7.7/Dockerfile
@@ -1,0 +1,12 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.7.1
+
+RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN echo "discovery.type: single-node" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN bin/elasticsearch-plugin install -b analysis-icu && \
+    bin/elasticsearch-plugin install -b analysis-phonetic
+
+ADD docker-healthcheck.sh /docker-healthcheck.sh
+
+HEALTHCHECK --retries=3 CMD ["bash", "/docker-healthcheck.sh"]
+
+EXPOSE 9200 9300

--- a/images/elasticsearch/7.7/docker-healthcheck.sh
+++ b/images/elasticsearch/7.7/docker-healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eo pipefail
+
+if health="$(curl -fsSL "http://${ES_HOST:-elasticsearch}:${ES_PORT:-9200}/_cat/health?h=status")"; then
+  health="$(echo "$health" | sed -r 's/^[[:space:]]+|[[:space:]]+$//g')" # trim whitespace (otherwise we'll have "green ")
+  if [ "$health" = 'green' ] || [ "$health" = 'yellow' ]; then
+    exit 0
+  fi
+  echo >&2 "Unexpected health status: $health"
+fi
+
+exit 1


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Added Elasticsearch 7.7 image
https://jira.corp.magento.com/browse/MCLOUD-6219

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Build Elasticsearch 7.7:
```bash
docker image build -t test/elasticsearch:7.7 vendor/magento/magento-cloud-docker/images/elasticsearch/7.7/
```
Generate `docker-compose` file:
```
./vendor/bin/ece-docker build:compose --es=7.7
```

Add `docker-compose.override.yml`

```yaml
version: '2.1'
services:
  elasticsearch:
    image: 'test/elasticsearch:7.7'
```
Install Magento on docker https://devdocs.magento.com/cloud/docker/docker-mode-production.html
### Release notes

Added support for Elasticsearch version 7.7.

### Associated documentation updates
<!--
 If your proposed update requires user documentation, submit a PR to the Magento DevDocs repository. For extensive updates requiring assistance, submit an issue to DevDocs. See https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md.
 -->
Add link to Magento DevDocs PR or Issue, if needed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [ ] All commits are accompanied by meaningful commit messages
