### PR TITLE
MCLOUD-6898: Add option to customize port for MailHog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /composer.lock
 /auth.json
 /_workdir
+/_workdir_cache
 .phpunit.result.cache

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -34,6 +34,10 @@ modules:
       printOutput: false
     PhpBrowser:
       url: "%Magento.docker.settings.env.url.base%"
+    REST:
+      depends: PhpBrowser
+      url: "%Magento.docker.settings.env.url.base%"
+      shortDebugResponse: 300
     Magento\CloudDocker\Test\Functional\Codeception\MagentoDb:
       dsn: "mysql:host=%Magento.docker.settings.db.host%;port=%Magento.docker.settings.db.port%;dbname=%Magento.docker.settings.db.path%"
       user: "%Magento.docker.settings.db.username%"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "codeception/module-asserts": "^1.2",
         "codeception/module-db": "^1.0",
         "codeception/module-phpbrowser": "^1.0",
+        "codeception/module-rest": "^1.2",
         "consolidation/robo": "^1.2",
         "phpmd/phpmd": "@stable",
         "phpstan/phpstan": "^0.11",

--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -172,6 +172,16 @@ class BuildCompose extends Command
                 InputOption::VALUE_NONE,
                 'Disable mailhog'
             )->addOption(
+                Source\CliSource::OPTION_MAILHOG_SMTP_PORT,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'MailHog SMTP port'
+            )->addOption(
+                Source\CliSource::OPTION_MAILHOG_HTTP_PORT,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'MailHog HTTP port'
+            )->addOption(
                 Source\CliSource::OPTION_SET_DOCKER_HOST_XDEBUG,
                 null,
                 InputOption::VALUE_NONE,

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -405,8 +405,8 @@ class ProductionBuilder implements BuilderInterface
                     $this->serviceFactory->getDefaultVersion(ServiceInterface::SERVICE_MAILHOG),
                     [
                         'ports' => [
-                            ($config->getMailHogSmtpPort() ?: '1025').':1025',
-                            ($config->getMailHogHttpPort() ?: '8025').':8025',
+                            $config->getMailHogSmtpPort() . ':1025',
+                            $config->getMailHogHttpPort() . ':8025',
                         ]
                     ]
                 ),

--- a/src/Compose/ProductionBuilder.php
+++ b/src/Compose/ProductionBuilder.php
@@ -402,7 +402,13 @@ class ProductionBuilder implements BuilderInterface
                 self::SERVICE_MAILHOG,
                 $this->serviceFactory->create(
                     ServiceInterface::SERVICE_MAILHOG,
-                    $this->serviceFactory->getDefaultVersion(ServiceInterface::SERVICE_MAILHOG)
+                    $this->serviceFactory->getDefaultVersion(ServiceInterface::SERVICE_MAILHOG),
+                    [
+                        'ports' => [
+                            ($config->getMailHogSmtpPort() ?: '1025').':1025',
+                            ($config->getMailHogHttpPort() ?: '8025').':8025',
+                        ]
+                    ]
                 ),
                 [self::NETWORK_MAGENTO],
                 []

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -454,4 +454,22 @@ class Config
             1
         );
     }
+
+    /**
+     * @return string|null
+     * @throws ConfigurationMismatchException
+     */
+    public function getMailHogSmtpPort(): ?string
+    {
+        return $this->all()->get(SourceInterface::SYSTEM_MAILHOG_SMTP_PORT);
+    }
+
+    /**
+     * @return string|null
+     * @throws ConfigurationMismatchException
+     */
+    public function getMailHogHttpPort(): ?string
+    {
+        return $this->all()->get(SourceInterface::SYSTEM_MAILHOG_HTTP_PORT);
+    }
 }

--- a/src/Config/Source/BaseSource.php
+++ b/src/Config/Source/BaseSource.php
@@ -30,7 +30,6 @@ class BaseSource implements SourceInterface
     public const DEFAULT_MAILHOG_SMTP_PORT = '1025';
     public const DEFAULT_MAILHOG_HTTP_PORT = '8025';
 
-
     /**
      * @var EnvReader
      */

--- a/src/Config/Source/BaseSource.php
+++ b/src/Config/Source/BaseSource.php
@@ -27,6 +27,9 @@ class BaseSource implements SourceInterface
     public const DEFAULT_HOST = 'magento2.docker';
     public const DEFAULT_PORT = '80';
     public const DEFAULT_TLS_PORT = '443';
+    public const DEFAULT_MAILHOG_SMTP_PORT = '1025';
+    public const DEFAULT_MAILHOG_HTTP_PORT = '8025';
+
 
     /**
      * @var EnvReader
@@ -73,7 +76,9 @@ class BaseSource implements SourceInterface
             self::SYSTEM_HOST => self::DEFAULT_HOST,
             self::SYSTEM_TLS_PORT => self::DEFAULT_TLS_PORT,
             self::INSTALLATION_TYPE => self::INSTALLATION_TYPE_COMPOSER,
-            self::MAGENTO_VERSION => $this->getMagentoVersion()
+            self::MAGENTO_VERSION => $this->getMagentoVersion(),
+            self::SYSTEM_MAILHOG_SMTP_PORT => self::DEFAULT_MAILHOG_SMTP_PORT,
+            self::SYSTEM_MAILHOG_HTTP_PORT => self::DEFAULT_MAILHOG_HTTP_PORT
         ]);
 
         try {

--- a/src/Config/Source/CliSource.php
+++ b/src/Config/Source/CliSource.php
@@ -35,6 +35,12 @@ class CliSource implements SourceInterface
     public const OPTION_NO_MAILHOG = 'no-mailhog';
 
     /**
+     * MailHog configuration
+     */
+    public const OPTION_MAILHOG_SMTP_PORT = 'mailhog-smtp-port';
+    public const OPTION_MAILHOG_HTTP_PORT = 'mailhog-http-port';
+
+    /**
      * State modifiers.
      */
     public const OPTION_NODE = 'node';
@@ -275,6 +281,14 @@ class CliSource implements SourceInterface
 
         if ($this->input->getOption(self::OPTION_WITH_MARIADB_CONF)) {
             $repository->set(SourceInterface::SYSTEM_MARIADB_CONF, true);
+        }
+
+        if ($port = $this->input->getOption(self::OPTION_MAILHOG_SMTP_PORT)) {
+            $repository->set(self::SYSTEM_MAILHOG_SMTP_PORT, $port);
+        }
+
+        if ($port = $this->input->getOption(self::OPTION_MAILHOG_HTTP_PORT)) {
+            $repository->set(self::SYSTEM_MAILHOG_HTTP_PORT, $port);
         }
 
         return $repository;

--- a/src/Config/Source/SourceInterface.php
+++ b/src/Config/Source/SourceInterface.php
@@ -143,6 +143,8 @@ interface SourceInterface
     public const SYSTEM_DB_ENTRYPOINT = 'system.db_entrypoint';
     public const SYSTEM_MARIADB_CONF = 'system.mariadb_conf';
     public const SYSTEM_SET_DOCKER_HOST = 'system.set_docker_host';
+    public const SYSTEM_MAILHOG_SMTP_PORT = 'system.mailhog.smtp_port';
+    public const SYSTEM_MAILHOG_HTTP_PORT = 'system.mailhog.http_port';
 
     public const SYSTEM_DB_INCREMENT_INCREMENT = 'system.db.increment_increment';
     public const SYSTEM_DB_INCREMENT_OFFSET = 'system.db.increment_offset';

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -132,7 +132,6 @@ class ServiceFactory
             'version' => 'latest',
             'pattern' => self::PATTERN_STD,
             'config' => [
-                'restart' => 'always',
                 'ports' => [
                     '1025:1025',
                     '8025:8025'

--- a/src/Test/Functional/Acceptance.suite.dist.yml
+++ b/src/Test/Functional/Acceptance.suite.dist.yml
@@ -6,3 +6,4 @@ modules:
     - Magento\CloudDocker\Test\Functional\Codeception\MagentoDb
     - PhpBrowser
     - Asserts
+    - REST

--- a/src/Test/Functional/Acceptance/MailHogCest.php
+++ b/src/Test/Functional/Acceptance/MailHogCest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CloudDocker\Test\Functional\Acceptance;
+
+/**
+ * @group php74
+ */
+class MailHogCest extends AbstractCest
+{
+    /**
+     * @param \CliTester $I
+     * @throws \Exception
+     */
+    public function testDefaultPorts(\CliTester $I): void
+    {
+        $I->updateBaseUrl('http://magento2.docker:8025/');
+        $I->assertTrue(
+            $I->runEceDockerCommand('build:compose'),
+            'Command build:compose failed'
+        );
+        $this->runAndAssert($I);
+    }
+
+    /**
+     * @param \CliTester $I
+     * @throws \Exception
+     */
+    public function testCustomPorts(\CliTester $I): void
+    {
+        $I->updateBaseUrl('http://magento2.docker:8026/');
+        $I->assertTrue(
+            $I->runEceDockerCommand('build:compose --mailhog-http-port=8026 --mailhog-smtp-port=1026'),
+            'Command build:compose failed'
+        );
+        $this->runAndAssert($I);
+    }
+
+    /**
+     * @param \CliTester $I
+     * @throws \Exception
+     */
+    private function runAndAssert(\CliTester $I): void
+    {
+        $I->replaceImagesWithGenerated();
+        $I->startEnvironment();
+        $I->amOnPage('/');
+        $I->see('MailHog');
+
+        $I->sendAjaxGetRequest('/api/v2/messages', ['limit' => 10]);
+        $I->seeResponseIsJson();
+        $I->assertSame([0], $I->grabDataFromResponseByJsonPath('$.total'));
+
+        $I->assertTrue(
+            $I->runDockerComposeCommand('run deploy bash -c "php -r \"mail(\'test@example.com\',\'test\',\'test\');\""')
+        );
+        $I->sendAjaxGetRequest('/api/v2/messages', ['limit' => 10]);
+        $I->seeResponseIsJson();
+        $I->assertSame([1], $I->grabDataFromResponseByJsonPath('$.total'));
+    }
+}

--- a/src/Test/Integration/BuildCustomComposeTest.php
+++ b/src/Test/Integration/BuildCustomComposeTest.php
@@ -85,6 +85,10 @@ class BuildCustomComposeTest extends TestCase
                                 'db' => [
                                     'increment_increment' => 3,
                                     'increment_offset' => 2
+                                ],
+                                'mailhog' => [
+                                    'smtp_port' => '1026',
+                                    'http_port' => '8026'
                                 ]
                             ],
                             'services' => [

--- a/src/Test/Integration/_files/cloud_base/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/cloud_base/docker-compose.exp.yml
@@ -170,7 +170,6 @@ services:
   mailhog:
     hostname: mailhog.magento2.docker
     image: 'mailhog/mailhog:latest'
-    restart: always
     ports:
       - '1025:1025'
       - '8025:8025'

--- a/src/Test/Integration/_files/custom_cloud_base/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/custom_cloud_base/docker-compose.exp.yml
@@ -138,8 +138,8 @@ services:
     image: 'mailhog/mailhog:latest'
     restart: always
     ports:
-      - '1025:1025'
-      - '8025:8025'
+      - '1026:1025'
+      - '8026:8025'
     networks:
       magento:
         aliases:

--- a/src/Test/Integration/_files/custom_cloud_base/docker-compose.exp.yml
+++ b/src/Test/Integration/_files/custom_cloud_base/docker-compose.exp.yml
@@ -136,7 +136,6 @@ services:
   mailhog:
     hostname: mailhog.magento2.test
     image: 'mailhog/mailhog:latest'
-    restart: always
     ports:
       - '1026:1025'
       - '8026:8025'


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added options to configure HTTP and SMTP ports for MailHog

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-docker#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- https://jira.corp.magento.com/browse/MCLOUD-6898
- https://jira.corp.magento.com/browse/MCLOUD-6917

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Covered with Integration and Functional tests

### Release notes

Added MailHog configuration options to the ece-docker build:compose command to customize the HTTP and SMTP ports, and to disable MailHog. See [Set up email](https://devdocs.magento.com/cloud/docker/docker-config.html#set-up-email).

### Associated documentation updates

https://github.com/magento/devdocs/pull/7860

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [ ] All commits are accompanied by meaningful commit messages
