### PR TITLE
Make <host.docker.internal> platform independent

### DIFF
--- a/images/php/7.2-fpm/Dockerfile
+++ b/images/php/7.2-fpm/Dockerfile
@@ -9,7 +9,6 @@ ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
 ENV UPDATE_UID_GID false
 ENV ENABLE_SENDMAIL true
-ENV SET_DOCKER_HOST false
 
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
@@ -21,6 +20,7 @@ RUN apt-get update \
   sendmail-bin \
   sendmail \
   sudo \
+  iproute2 \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \

--- a/images/php/7.2-fpm/docker-entrypoint.sh
+++ b/images/php/7.2-fpm/docker-entrypoint.sh
@@ -58,11 +58,12 @@ fi
 # Configure PHP-FPM
 [ ! -z "${MAGENTO_RUN_MODE}" ] && sed -i "s/!MAGENTO_RUN_MODE!/${MAGENTO_RUN_MODE}/" /usr/local/etc/php-fpm.conf
 
-# Set host.docker.inernal for LINUX os
-if [[ "$SET_DOCKER_HOST" = "true" ]]; then
-  apt update
-  apt install -y iproute2
-  echo -e "`/sbin/ip route|awk '/default/ { print $3 }'`\thost.docker.internal" | sudo tee -a /etc/hosts > /dev/null
+# Set host.docker.inernal if not available
+HOST_NAME="host.docker.internal"
+HOST_IP=$(php -r "putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1'); echo gethostbyname('$HOST_NAME');")
+if [[ "$HOST_IP" == "$HOST_NAME" ]]; then
+  HOST_IP=$(/sbin/ip route|awk '/default/ { print $3 }')
+  printf "\n%s %s\n" "$HOST_IP" "$HOST_NAME" >> /etc/hosts
 fi
 
 exec "$@"

--- a/images/php/7.3-fpm/Dockerfile
+++ b/images/php/7.3-fpm/Dockerfile
@@ -9,7 +9,6 @@ ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
 ENV UPDATE_UID_GID false
 ENV ENABLE_SENDMAIL true
-ENV SET_DOCKER_HOST false
 
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
@@ -21,6 +20,7 @@ RUN apt-get update \
   sendmail-bin \
   sendmail \
   sudo \
+  iproute2 \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \

--- a/images/php/7.3-fpm/docker-entrypoint.sh
+++ b/images/php/7.3-fpm/docker-entrypoint.sh
@@ -58,11 +58,12 @@ fi
 # Configure PHP-FPM
 [ ! -z "${MAGENTO_RUN_MODE}" ] && sed -i "s/!MAGENTO_RUN_MODE!/${MAGENTO_RUN_MODE}/" /usr/local/etc/php-fpm.conf
 
-# Set host.docker.inernal for LINUX os
-if [[ "$SET_DOCKER_HOST" = "true" ]]; then
-  apt update
-  apt install -y iproute2
-  echo -e "`/sbin/ip route|awk '/default/ { print $3 }'`\thost.docker.internal" | sudo tee -a /etc/hosts > /dev/null
+# Set host.docker.inernal if not available
+HOST_NAME="host.docker.internal"
+HOST_IP=$(php -r "putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1'); echo gethostbyname('$HOST_NAME');")
+if [[ "$HOST_IP" == "$HOST_NAME" ]]; then
+  HOST_IP=$(/sbin/ip route|awk '/default/ { print $3 }')
+  printf "\n%s %s\n" "$HOST_IP" "$HOST_NAME" >> /etc/hosts
 fi
 
 exec "$@"

--- a/images/php/7.4-fpm/Dockerfile
+++ b/images/php/7.4-fpm/Dockerfile
@@ -9,7 +9,6 @@ ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
 ENV UPDATE_UID_GID false
 ENV ENABLE_SENDMAIL true
-ENV SET_DOCKER_HOST false
 
 ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sysvmsg sysvsem sysvshm xsl zip pcntl
 
@@ -21,6 +20,7 @@ RUN apt-get update \
   sendmail-bin \
   sendmail \
   sudo \
+  iproute2 \
   libbz2-dev \
   libjpeg62-turbo-dev \
   libpng-dev \

--- a/images/php/7.4-fpm/docker-entrypoint.sh
+++ b/images/php/7.4-fpm/docker-entrypoint.sh
@@ -58,11 +58,12 @@ fi
 # Configure PHP-FPM
 [ ! -z "${MAGENTO_RUN_MODE}" ] && sed -i "s/!MAGENTO_RUN_MODE!/${MAGENTO_RUN_MODE}/" /usr/local/etc/php-fpm.conf
 
-# Set host.docker.inernal for LINUX os
-if [[ "$SET_DOCKER_HOST" = "true" ]]; then
-  apt update
-  apt install -y iproute2
-  echo -e "`/sbin/ip route|awk '/default/ { print $3 }'`\thost.docker.internal" | sudo tee -a /etc/hosts > /dev/null
+# Set host.docker.inernal if not available
+HOST_NAME="host.docker.internal"
+HOST_IP=$(php -r "putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1'); echo gethostbyname('$HOST_NAME');")
+if [[ "$HOST_IP" == "$HOST_NAME" ]]; then
+  HOST_IP=$(/sbin/ip route|awk '/default/ { print $3 }')
+  printf "\n%s %s\n" "$HOST_IP" "$HOST_NAME" >> /etc/hosts
 fi
 
 exec "$@"

--- a/images/php/fpm/Dockerfile
+++ b/images/php/fpm/Dockerfile
@@ -9,7 +9,6 @@ ENV MAGENTO_RUN_MODE production
 ENV UPLOAD_MAX_FILESIZE 64M
 ENV UPDATE_UID_GID false
 ENV ENABLE_SENDMAIL true
-ENV SET_DOCKER_HOST false
 
 {%env_php_extensions%}
 

--- a/images/php/fpm/docker-entrypoint.sh
+++ b/images/php/fpm/docker-entrypoint.sh
@@ -58,11 +58,12 @@ fi
 # Configure PHP-FPM
 [ ! -z "${MAGENTO_RUN_MODE}" ] && sed -i "s/!MAGENTO_RUN_MODE!/${MAGENTO_RUN_MODE}/" /usr/local/etc/php-fpm.conf
 
-# Set host.docker.inernal for LINUX os
-if [[ "$SET_DOCKER_HOST" = "true" ]]; then
-  apt update
-  apt install -y iproute2
-  echo -e "`/sbin/ip route|awk '/default/ { print $3 }'`\thost.docker.internal" | sudo tee -a /etc/hosts > /dev/null
+# Set host.docker.inernal if not available
+HOST_NAME="host.docker.internal"
+HOST_IP=$(php -r "putenv('RES_OPTIONS=retrans:1 retry:1 timeout:1 attempts:1'); echo gethostbyname('$HOST_NAME');")
+if [[ "$HOST_IP" == "$HOST_NAME" ]]; then
+  HOST_IP=$(/sbin/ip route|awk '/default/ { print $3 }')
+  printf "\n%s %s\n" "$HOST_IP" "$HOST_NAME" >> /etc/hosts
 fi
 
 exec "$@"

--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -182,6 +182,11 @@ class BuildCompose extends Command
                 InputOption::VALUE_REQUIRED,
                 'MailHog HTTP port'
             )->addOption(
+                Source\CliSource::OPTION_SET_DOCKER_HOST_XDEBUG,
+                null,
+                InputOption::VALUE_NONE,
+                'Deprecated option to resolve host.docker.internal on Linux. Did nothing at the moment'
+            )->addOption(
                 Source\CliSource::OPTION_NGINX_WORKER_PROCESSES,
                 null,
                 InputOption::VALUE_OPTIONAL,

--- a/src/Command/BuildCompose.php
+++ b/src/Command/BuildCompose.php
@@ -181,11 +181,6 @@ class BuildCompose extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'MailHog HTTP port'
-            )->addOption(
-                Source\CliSource::OPTION_SET_DOCKER_HOST_XDEBUG,
-                null,
-                InputOption::VALUE_NONE,
-                'Sets host.docker.internal for fpm_xdebug container to resolve debug issue for LINUX system'
             );
 
         $this->addOption(

--- a/src/Command/Image/GeneratePhp.php
+++ b/src/Command/Image/GeneratePhp.php
@@ -35,7 +35,8 @@ class GeneratePhp extends Command
         'apt-utils',
         'sendmail-bin',
         'sendmail',
-        'sudo'
+        'sudo',
+        'iproute2'
     ];
     private const DEFAULT_PACKAGES_PHP_CLI = [
         'apt-utils',

--- a/src/Compose/ProductionBuilder/Service/FpmXdebug.php
+++ b/src/Compose/ProductionBuilder/Service/FpmXdebug.php
@@ -84,9 +84,6 @@ class FpmXdebug implements ServiceBuilderInterface
         $envVariables = [
             'PHP_EXTENSIONS' => implode(' ', array_unique(array_merge($this->phpExtension->get($config), ['xdebug'])))
         ];
-        if ($config->get(SourceInterface::SYSTEM_SET_DOCKER_HOST)) {
-            $envVariables['SET_DOCKER_HOST'] = true;
-        }
 
         return $this->serviceFactory->create(
             $this->getServiceName(),

--- a/src/Config/Source/CliSource.php
+++ b/src/Config/Source/CliSource.php
@@ -57,6 +57,11 @@ class CliSource implements SourceInterface
     public const OPTION_WITH_MARIADB_CONF = 'with-mariadb-conf';
 
     /**
+     * @deprecated Will be removed in next major release
+     */
+    public const OPTION_SET_DOCKER_HOST_XDEBUG = 'set-docker-host';
+
+    /**
      * Environment variables.
      */
     public const OPTION_ENV_VARIABLES = 'env-vars';

--- a/src/Config/Source/CliSource.php
+++ b/src/Config/Source/CliSource.php
@@ -52,7 +52,6 @@ class CliSource implements SourceInterface
     public const OPTION_NO_TMP_MOUNTS = 'no-tmp-mounts';
     public const OPTION_SYNC_ENGINE = 'sync-engine';
     public const OPTION_WITH_XDEBUG = 'with-xdebug';
-    public const OPTION_SET_DOCKER_HOST_XDEBUG = 'set-docker-host';
     public const OPTION_WITH_ENTRYPOINT = 'with-entrypoint';
     public const OPTION_WITH_MARIADB_CONF = 'with-mariadb-conf';
 
@@ -232,10 +231,6 @@ class CliSource implements SourceInterface
             $repository->set([
                 self::SERVICES_XDEBUG . '.enabled' => true
             ]);
-        }
-
-        if ($this->input->getOption(self::OPTION_SET_DOCKER_HOST_XDEBUG)) {
-            $repository->set(self::SYSTEM_SET_DOCKER_HOST, true);
         }
 
         if ($envs = $this->input->getOption(self::OPTION_ENV_VARIABLES)) {

--- a/src/Config/Source/SourceInterface.php
+++ b/src/Config/Source/SourceInterface.php
@@ -139,7 +139,6 @@ interface SourceInterface
     public const SYSTEM_EXPOSE_DB_SALES_PORTS = 'system.expose_db_sales_ports';
     public const SYSTEM_DB_ENTRYPOINT = 'system.db_entrypoint';
     public const SYSTEM_MARIADB_CONF = 'system.mariadb_conf';
-    public const SYSTEM_SET_DOCKER_HOST = 'system.set_docker_host';
     public const SYSTEM_MAILHOG_SMTP_PORT = 'system.mailhog.smtp_port';
     public const SYSTEM_MAILHOG_HTTP_PORT = 'system.mailhog.http_port';
 


### PR DESCRIPTION
### Description
It is not possible to generate unified **docker-compose** script for different operation systems because of requirement to set additional ENV variable for Ubuntu - "**SET_DOCKER_HOST**" (if you want to use XDEBUG). If it is set - docker container will install additional package "**iproute2**" and override **/etc/hosts** file (will add - "**host.docker.internal**" line). 

On **Windows/Mac** it is available by in-built DNS server, so this variable should be used only on **Linux**. Currently my goal to setup single behavior for all our devs and the only thing which I need to solve by workaround is this variable.

**This PR includes:**
1. "iproute2" package added to FPM image during image build (removed it's installing from startup entry-point script).
2. Added check for "host.docker.internal" availability - if not available - add it.
This will be done once at first container startup - on the next startup for the same container - "host.docker.internal" will be available already.
3. Removed additional option - "**--set-docker-host**" and it's ENV variable "**SET_DOCKER_HOST**", since this is not needed anymore.
4. Tested on Ubuntu/Windows/Mac

### Manual testing scenarios
1. Configure Xdebug on Windows / Ubuntu - it should work using same behavior. You don't need to use custom XDEBUG_HOST value or "**--set-docker-host**" option.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [x] All commits are accompanied by meaningful commit messages
