### PR TITLE
Add mounts object in Magento cloud application

### DIFF
--- a/src/Config/Dist/Generator.php
+++ b/src/Config/Dist/Generator.php
@@ -184,7 +184,8 @@ class Generator
                 'ADMIN_URL' => 'admin'
             ],
             'MAGENTO_CLOUD_APPLICATION' => [
-                'hooks' => $config->getHooks()
+                'hooks' => $config->getHooks(),
+                'mounts' => $config->getMounts()
             ]
         ];
     }

--- a/src/Test/Unit/Config/Dist/GeneratorTest.php
+++ b/src/Test/Unit/Config/Dist/GeneratorTest.php
@@ -182,7 +182,8 @@ class GeneratorTest extends TestCase
                 ],
                 [
                     [
-                        'hooks' => []
+                        'hooks' => [],
+                        'mounts' => []
                     ],
                     2,
                     'exported_application_value',

--- a/src/Test/Unit/Config/Dist/GeneratorTest.php
+++ b/src/Test/Unit/Config/Dist/GeneratorTest.php
@@ -136,7 +136,8 @@ class GeneratorTest extends TestCase
                     'ADMIN_URL' => 'admin'
                 ],
                 'MAGENTO_CLOUD_APPLICATION' => [
-                    'hooks' => []
+                    'hooks' => [],
+                    'mounts' => []
                 ],
             ])
             ->willReturn([


### PR DESCRIPTION

### Description

1.  Added 'mounts' object in the 'MAGENTO_CLOUD_APPLICATION'. Which is missed. 
2.  This PR reverts the temporary fix introduced in magento/ece-tools#781

### Fixed Issues (if relevant)

1. magento/magento-cloud-docker#292: The application environment variable does not contain mounts.

### Release notes

For user-facing changes, add a meaningful release note. For examples, see [Magento Cloud Docker release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [ ] All commits are accompanied by meaningful commit messages
