### PR TITLE
Add ioncube support for PHP7.4

### DIFF
--- a/images/php/7.4-cli/Dockerfile
+++ b/images/php/7.4-cli/Dockerfile
@@ -135,6 +135,14 @@ RUN rm -f /usr/local/etc/php/conf.d/*sodium.ini \
   && cd / \
   && rm -rf /tmp/libsodium  \
   && pecl install -o -f libsodium
+RUN cd /tmp \
+  && curl -O https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz \
+  && tar zxvf ioncube_loaders_lin_x86-64.tar.gz \
+  && export PHP_VERSION=$(php -r "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;") \
+  && export PHP_EXT_DIR=$(php-config --extension-dir) \
+  && cp "./ioncube/ioncube_loader_lin_${PHP_VERSION}.so" "${PHP_EXT_DIR}/ioncube.so" \
+  && rm -rf ./ioncube \
+  && rm ioncube_loaders_lin_x86-64.tar.gz
 
 RUN docker-php-ext-enable \
   bcmath \
@@ -175,7 +183,8 @@ RUN docker-php-ext-enable \
   xsl \
   yaml \
   zip \
-  pcntl
+  pcntl \
+  ioncube
 
 ADD etc/php-cli.ini /usr/local/etc/php/conf.d/zz-magento.ini
 ADD etc/php-xdebug.ini /usr/local/etc/php/conf.d/zz-xdebug-settings.ini

--- a/images/php/7.4-fpm/Dockerfile
+++ b/images/php/7.4-fpm/Dockerfile
@@ -114,6 +114,14 @@ RUN rm -f /usr/local/etc/php/conf.d/*sodium.ini \
   && cd / \
   && rm -rf /tmp/libsodium  \
   && pecl install -o -f libsodium
+  RUN cd /tmp \
+  && curl -O https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz \
+  && tar zxvf ioncube_loaders_lin_x86-64.tar.gz \
+  && export PHP_VERSION=$(php -r "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;") \
+  && export PHP_EXT_DIR=$(php-config --extension-dir) \
+  && cp "./ioncube/ioncube_loader_lin_${PHP_VERSION}.so" "${PHP_EXT_DIR}/ioncube.so" \
+  && rm -rf ./ioncube \
+  && rm ioncube_loaders_lin_x86-64.tar.gz
 
 RUN docker-php-ext-enable \
   bcmath \
@@ -154,7 +162,8 @@ RUN docker-php-ext-enable \
   xsl \
   yaml \
   zip \
-  pcntl
+  pcntl \
+  ioncube
 
 RUN groupadd -g 1000 www && useradd -g 1000 -u 1000 -d ${MAGENTO_ROOT} -s /bin/bash www
 

--- a/src/Compose/Php/ExtensionResolver.php
+++ b/src/Compose/Php/ExtensionResolver.php
@@ -423,7 +423,7 @@ BASH
                 '>=7.0' => [self::EXTENSION_TYPE => self::EXTENSION_TYPE_CORE],
             ],
             'ioncube' => [
-                '>=7.0 <=7.3' => [
+                '>=7.0 <=7.4' => [
                     self::EXTENSION_TYPE => self::EXTENSION_TYPE_INSTALLATION_SCRIPT,
                     self::EXTENSION_INSTALLATION_SCRIPT => <<< BASH
 cd /tmp


### PR DESCRIPTION
Adds back in support for ioncube extension with PHP 7.4 images. Code is identical to what is used for PHP 7.3 so should be able to merge quickly.

### Description
Adds back missing code which was excluded in the first builds of PHP 7.4 images.
