### PR TITLE
remove volume deletion from "up" and "down" CLI commands

### DIFF
--- a/dist/bin/magento-docker
+++ b/dist/bin/magento-docker
@@ -6,7 +6,8 @@ USAGE="Magento Cloud Docker
 
 \033[33mArguments:\033[0m
   pull              pull latest images
-  up                destroy, re-create and start containers
+  init              destroy, re-create and start containers and volumes
+  up                create or start containers
   down              destroy containers
   bash              connect to bash
   stop              stop containers
@@ -40,12 +41,20 @@ case "$1" in
     pull)
         docker-compose pull
         ;;
+    init)
+        read -p "Any existing data volumes will be removed. Are you sure? [y/N] " -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]
+        then
+            docker-compose down --volumes
+            docker-compose up --detach
+        fi
+        ;;
     up)
-        docker-compose down --volumes
         docker-compose up --detach
         ;;
     down)
-        docker-compose down --volumes
+        docker-compose down
         ;;
     bash)
         docker-compose run --rm deploy bash


### PR DESCRIPTION
### Description
Removed "--volume" option from `bin/magento-docker up` and `bin/magento-docker down` commands.
Created `bin/magento-docker init` command with data loss warning.
Updated self-documentation.

### Fixed Issues (if relevant)
Less likelihood of accidentally deleting data.

### Manual testing scenarios
Check for desired results from:
`bin/magento-docker`
`bin/magento-docker up`
`bin/magento-docker down`
`bin/magento-docker init`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [ ] All commits are accompanied by meaningful commit messages
