### PR TITLE
Added n98-magerun2 command to CLI containers

### DIFF
--- a/images/php/7.2-cli/Dockerfile
+++ b/images/php/7.2-cli/Dockerfile
@@ -189,6 +189,9 @@ ADD etc/php-gnupg.ini /usr/local/etc/php/conf.d/gnupg.ini
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --version=${COMPOSER_VERSION} --filename=composer
 
+# Install n98-magerun2.phar and move to /usr/local/bin/
+RUN curl -O https://files.magerun.net/n98-magerun2.phar && chmod +x ./n98-magerun2.phar && mv ./n98-magerun2.phar /usr/local/bin/
+
 ADD bin/* /usr/local/bin/
 
 RUN groupadd -g 1000 www && useradd -g 1000 -u 1000 -d ${MAGENTO_ROOT} -s /bin/bash www
@@ -205,7 +208,8 @@ RUN ["chmod", "+x", \
     "/usr/local/bin/cloud-deploy", \
     "/usr/local/bin/cloud-post-deploy", \
     "/usr/local/bin/run-cron", \
-    "/usr/local/bin/run-hooks" \
+    "/usr/local/bin/run-hooks", \
+    "/usr/local/bin/magerun2" \
 ]
 
 RUN mkdir -p ${MAGENTO_ROOT}

--- a/images/php/7.2-cli/bin/magerun2
+++ b/images/php/7.2-cli/bin/magerun2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+su www-data -s /bin/bash -c "n98-magerun2.phar --root-dir=$MAGENTO_ROOT $*"

--- a/images/php/7.3-cli/Dockerfile
+++ b/images/php/7.3-cli/Dockerfile
@@ -186,6 +186,9 @@ ADD etc/php-gnupg.ini /usr/local/etc/php/conf.d/gnupg.ini
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --version=${COMPOSER_VERSION} --filename=composer
 
+# Install n98-magerun2.phar and move to /usr/local/bin/
+RUN curl -O https://files.magerun.net/n98-magerun2.phar && chmod +x ./n98-magerun2.phar && mv ./n98-magerun2.phar /usr/local/bin/
+
 ADD bin/* /usr/local/bin/
 
 RUN groupadd -g 1000 www && useradd -g 1000 -u 1000 -d ${MAGENTO_ROOT} -s /bin/bash www
@@ -202,7 +205,8 @@ RUN ["chmod", "+x", \
     "/usr/local/bin/cloud-deploy", \
     "/usr/local/bin/cloud-post-deploy", \
     "/usr/local/bin/run-cron", \
-    "/usr/local/bin/run-hooks" \
+    "/usr/local/bin/run-hooks", \
+    "/usr/local/bin/magerun2" \
 ]
 
 RUN mkdir -p ${MAGENTO_ROOT}

--- a/images/php/7.3-cli/bin/magerun2
+++ b/images/php/7.3-cli/bin/magerun2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+su www-data -s /bin/bash -c "n98-magerun2.phar --root-dir=$MAGENTO_ROOT $*"

--- a/images/php/7.4-cli/Dockerfile
+++ b/images/php/7.4-cli/Dockerfile
@@ -176,6 +176,9 @@ ADD etc/php-gnupg.ini /usr/local/etc/php/conf.d/gnupg.ini
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --version=${COMPOSER_VERSION} --filename=composer
 
+# Install n98-magerun2.phar and move to /usr/local/bin/
+RUN curl -O https://files.magerun.net/n98-magerun2.phar && chmod +x ./n98-magerun2.phar && mv ./n98-magerun2.phar /usr/local/bin/
+
 ADD bin/* /usr/local/bin/
 
 RUN groupadd -g 1000 www && useradd -g 1000 -u 1000 -d ${MAGENTO_ROOT} -s /bin/bash www
@@ -192,7 +195,8 @@ RUN ["chmod", "+x", \
     "/usr/local/bin/cloud-deploy", \
     "/usr/local/bin/cloud-post-deploy", \
     "/usr/local/bin/run-cron", \
-    "/usr/local/bin/run-hooks" \
+    "/usr/local/bin/run-hooks", \
+    "/usr/local/bin/magerun2" \
 ]
 
 RUN mkdir -p ${MAGENTO_ROOT}

--- a/images/php/7.4-cli/bin/magerun2
+++ b/images/php/7.4-cli/bin/magerun2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+su www-data -s /bin/bash -c "n98-magerun2.phar --root-dir=$MAGENTO_ROOT $*"

--- a/images/php/8.0-cli/Dockerfile
+++ b/images/php/8.0-cli/Dockerfile
@@ -161,6 +161,9 @@ ADD etc/php-gnupg.ini /usr/local/etc/php/conf.d/gnupg.ini
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --version=${COMPOSER_VERSION} --filename=composer
 
+# Install n98-magerun2.phar and move to /usr/local/bin/
+RUN curl -O https://files.magerun.net/n98-magerun2.phar && chmod +x ./n98-magerun2.phar && mv ./n98-magerun2.phar /usr/local/bin/
+
 ADD bin/* /usr/local/bin/
 
 RUN groupadd -g 1000 www && useradd -g 1000 -u 1000 -d ${MAGENTO_ROOT} -s /bin/bash www
@@ -177,7 +180,8 @@ RUN ["chmod", "+x", \
     "/usr/local/bin/cloud-deploy", \
     "/usr/local/bin/cloud-post-deploy", \
     "/usr/local/bin/run-cron", \
-    "/usr/local/bin/run-hooks" \
+    "/usr/local/bin/run-hooks", \
+    "/usr/local/bin/magerun2" \
 ]
 
 RUN mkdir -p ${MAGENTO_ROOT}

--- a/images/php/8.0-cli/bin/magerun2
+++ b/images/php/8.0-cli/bin/magerun2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+su www-data -s /bin/bash -c "n98-magerun2.phar --root-dir=$MAGENTO_ROOT $*"

--- a/images/php/8.1-cli/Dockerfile
+++ b/images/php/8.1-cli/Dockerfile
@@ -161,6 +161,9 @@ ADD etc/php-gnupg.ini /usr/local/etc/php/conf.d/gnupg.ini
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --version=${COMPOSER_VERSION} --filename=composer
 
+# Install n98-magerun2.phar and move to /usr/local/bin/
+RUN curl -O https://files.magerun.net/n98-magerun2.phar && chmod +x ./n98-magerun2.phar && mv ./n98-magerun2.phar /usr/local/bin/
+
 ADD bin/* /usr/local/bin/
 
 RUN groupadd -g 1000 www && useradd -g 1000 -u 1000 -d ${MAGENTO_ROOT} -s /bin/bash www
@@ -177,7 +180,8 @@ RUN ["chmod", "+x", \
     "/usr/local/bin/cloud-deploy", \
     "/usr/local/bin/cloud-post-deploy", \
     "/usr/local/bin/run-cron", \
-    "/usr/local/bin/run-hooks" \
+    "/usr/local/bin/run-hooks", \
+    "/usr/local/bin/magerun2" \
 ]
 
 RUN mkdir -p ${MAGENTO_ROOT}

--- a/images/php/8.1-cli/bin/magerun2
+++ b/images/php/8.1-cli/bin/magerun2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+su www-data -s /bin/bash -c "n98-magerun2.phar --root-dir=$MAGENTO_ROOT $*"

--- a/images/php/cli/Dockerfile
+++ b/images/php/cli/Dockerfile
@@ -60,6 +60,9 @@ ADD etc/php-gnupg.ini /usr/local/etc/php/conf.d/gnupg.ini
 # Get composer installed to /usr/local/bin/composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --version=${COMPOSER_VERSION} --filename=composer
 
+# Install n98-magerun2.phar and move to /usr/local/bin/
+RUN curl -O https://files.magerun.net/n98-magerun2.phar && chmod +x ./n98-magerun2.phar && mv ./n98-magerun2.phar /usr/local/bin/
+
 ADD bin/* /usr/local/bin/
 
 RUN groupadd -g 1000 www && useradd -g 1000 -u 1000 -d ${MAGENTO_ROOT} -s /bin/bash www
@@ -76,7 +79,8 @@ RUN ["chmod", "+x", \
     "/usr/local/bin/cloud-deploy", \
     "/usr/local/bin/cloud-post-deploy", \
     "/usr/local/bin/run-cron", \
-    "/usr/local/bin/run-hooks" \
+    "/usr/local/bin/run-hooks", \
+    "/usr/local/bin/magerun2" \
 ]
 
 {%volumes_cmd%}

--- a/images/php/cli/bin/magerun2
+++ b/images/php/cli/bin/magerun2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+su www-data -s /bin/bash -c "n98-magerun2.phar --root-dir=$MAGENTO_ROOT $*"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds the N98-Magerun2 binary to the CLI containers to be used during development. Magerun can be ran in a similar fashion as the other commands.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-docker#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Resolves magento/magento-cloud-docker#345

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
E.g. in the `images/php/7.4-cli` folder:
1. `docker build --tag magento/magento-cloud-docker-php:7.4-cli-1.3.2-magerun .`
2. `docker run --rm magento/magento-cloud-docker-php:7.4-cli-1.3.2-magerun magerun2 list`

It should output the list of possible commands. I have noticed that for me it was required to force ANSI output with the `--ansi` flag; is this only on my machine, or reproducible across the board? If the latter we should consider updating the `magerun2` command to always pass the `--ansi` flag.

I have tested the `7.2-cli`, `7.3-cli` and `7.4-cli` containers. I might have missed some incompatibility somewhere.

### Release notes

> For user-facing changes, add a meaningful release note. For examples, see [Magento Cloud Docker release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).

```
Added N98-Magerun2 binary to CLI containers.
```


### Associated documentation updates
<!--
 If your proposed update requires user documentation, submit a PR to the Magento DevDocs repository. For extensive updates requiring assistance, submit an issue to DevDocs. See https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md.
 -->

> Add link to Magento DevDocs PR or Issue, if needed.

If this change will be accepted I will do the digging in the DevDocs to add references to this functionality to it.

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [X] All commits are accompanied by meaningful commit messages
