### PR TITLE
Add support for Elasticsearch 7.16 and 7.17

### DIFF
--- a/images/elasticsearch/7.16/Dockerfile
+++ b/images/elasticsearch/7.16/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+
+RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN echo "discovery.type: single-node" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN bin/elasticsearch-plugin install -b analysis-icu && \
+    bin/elasticsearch-plugin install -b analysis-phonetic
+
+ADD docker-healthcheck.sh /docker-healthcheck.sh
+ADD docker-entrypoint.sh /docker-entrypoint.sh
+
+HEALTHCHECK --retries=3 CMD ["bash", "/docker-healthcheck.sh"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 9200 9300

--- a/images/elasticsearch/7.16/docker-entrypoint.sh
+++ b/images/elasticsearch/7.16/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eo pipefail
+
+if [[ -n "$ES_PLUGINS" ]]; then
+  echo "Installing plugins: $ES_PLUGNS"
+  for PLUGIN in $ES_PLUGINS
+  do
+      ./bin/elasticsearch-plugin install -b "$PLUGIN"
+  done
+fi
+
+/bin/bash /usr/local/bin/docker-entrypoint.sh

--- a/images/elasticsearch/7.16/docker-healthcheck.sh
+++ b/images/elasticsearch/7.16/docker-healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eo pipefail
+
+if health="$(curl -fsSL "http://${ES_HOST:-elasticsearch}:${ES_PORT:-9200}/_cat/health?h=status")"; then
+  health="$(echo "$health" | sed -r 's/^[[:space:]]+|[[:space:]]+$//g')" # trim whitespace (otherwise we'll have "green ")
+  if [ "$health" = 'green' ] || [ "$health" = 'yellow' ]; then
+    exit 0
+  fi
+  echo >&2 "Unexpected health status: $health"
+fi
+
+exit 1

--- a/images/elasticsearch/7.17/Dockerfile
+++ b/images/elasticsearch/7.17/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.8
+
+RUN echo "xpack.security.enabled: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN echo "discovery.type: single-node" >> /usr/share/elasticsearch/config/elasticsearch.yml
+RUN bin/elasticsearch-plugin install -b analysis-icu && \
+    bin/elasticsearch-plugin install -b analysis-phonetic
+
+ADD docker-healthcheck.sh /docker-healthcheck.sh
+ADD docker-entrypoint.sh /docker-entrypoint.sh
+
+HEALTHCHECK --retries=3 CMD ["bash", "/docker-healthcheck.sh"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 9200 9300

--- a/images/elasticsearch/7.17/docker-entrypoint.sh
+++ b/images/elasticsearch/7.17/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eo pipefail
+
+if [[ -n "$ES_PLUGINS" ]]; then
+  echo "Installing plugins: $ES_PLUGNS"
+  for PLUGIN in $ES_PLUGINS
+  do
+      ./bin/elasticsearch-plugin install -b "$PLUGIN"
+  done
+fi
+
+/bin/bash /usr/local/bin/docker-entrypoint.sh

--- a/images/elasticsearch/7.17/docker-healthcheck.sh
+++ b/images/elasticsearch/7.17/docker-healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eo pipefail
+
+if health="$(curl -fsSL "http://${ES_HOST:-elasticsearch}:${ES_PORT:-9200}/_cat/health?h=status")"; then
+  health="$(echo "$health" | sed -r 's/^[[:space:]]+|[[:space:]]+$//g')" # trim whitespace (otherwise we'll have "green ")
+  if [ "$health" = 'green' ] || [ "$health" = 'yellow' ]; then
+    exit 0
+  fi
+  echo >&2 "Unexpected health status: $health"
+fi
+
+exit 1


### PR DESCRIPTION
### Description
The images for Elasticsearch are outdated and versions are unsupported by recent Adobe Commerce / Magento releases (https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html). The PR adds support for Elasticsearch 7.16 and 7.17 to match system requirements.

### Fixed Issues
The upstream images switched their base image from centos:8 to ubuntu:20.04. Furthermore the log4j vulnerability has been fixed in ES 7.16 (https://www.elastic.co/de/blog/new-elasticsearch-and-logstash-releases-upgrade-apache-log4j2). Hence the patching of the log4j class is not required and the `Dockerfile` can be simplified. 

### Manual testing scenarios
Build for both new Elastcisearch version can be tested by:
1. docker build -f images/elasticsearch/7.16/Dockerfile images/elasticsearch/7.16 
2. docker build -f images/elasticsearch/7.17/Dockerfile images/elasticsearch/7.17 

### Release notes
- Added support for Elasticsearch 7.16 and 7.17