### PR TITLE
Adding JQ command to PHP CLI image

### DIFF
--- a/images/php/7.2-cli/Dockerfile
+++ b/images/php/7.2-cli/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
   unzip \
   vim \
   openssh-client \
+  jq \
   gnupg2 \
   ca-certificates \
   lsb-release \

--- a/images/php/7.2-cli/docker-entrypoint.sh
+++ b/images/php/7.2-cli/docker-entrypoint.sh
@@ -19,6 +19,7 @@ fi
 
 # Configure composer
 [ ! -z "${COMPOSER_VERSION}" ] && \
+    composer clearcache && \
     composer self-update $COMPOSER_VERSION
 
 [ ! -z "${COMPOSER_GITHUB_TOKEN}" ] && \

--- a/images/php/7.3-cli/Dockerfile
+++ b/images/php/7.3-cli/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
   unzip \
   vim \
   openssh-client \
+  jq \
   gnupg2 \
   ca-certificates \
   lsb-release \

--- a/images/php/7.3-cli/docker-entrypoint.sh
+++ b/images/php/7.3-cli/docker-entrypoint.sh
@@ -19,6 +19,7 @@ fi
 
 # Configure composer
 [ ! -z "${COMPOSER_VERSION}" ] && \
+    composer clearcache && \
     composer self-update $COMPOSER_VERSION
 
 [ ! -z "${COMPOSER_GITHUB_TOKEN}" ] && \

--- a/images/php/7.4-cli/Dockerfile
+++ b/images/php/7.4-cli/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
   unzip \
   vim \
   openssh-client \
+  jq \
   gnupg2 \
   ca-certificates \
   lsb-release \

--- a/images/php/8.0-cli/Dockerfile
+++ b/images/php/8.0-cli/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
   unzip \
   vim \
   openssh-client \
+  jq \
   gnupg2 \
   ca-certificates \
   lsb-release \

--- a/images/php/8.1-cli/Dockerfile
+++ b/images/php/8.1-cli/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
   unzip \
   vim \
   openssh-client \
+  jq \
   gnupg2 \
   ca-certificates \
   lsb-release \

--- a/images/php/8.2-cli/Dockerfile
+++ b/images/php/8.2-cli/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
   unzip \
   vim \
   openssh-client \
+  jq \
   gnupg2 \
   ca-certificates \
   lsb-release \

--- a/src/Command/Image/GeneratePhp.php
+++ b/src/Command/Image/GeneratePhp.php
@@ -66,6 +66,7 @@ class GeneratePhp extends Command
         'unzip',
         'vim',
         'openssh-client',
+        'jq'
     ];
 
     private const PHP_EXTENSIONS_ENABLED_BY_DEFAULT = [


### PR DESCRIPTION
### Description
Magento/Adobe Commerce Cloud ENVs are using "base64 + json encoded" ENV variables for storing credentials & configuration. Like:

- MAGENTO_CLOUD_RELATIONSHIPS

You would need to read this ENV variable in case when it is required to build a cross-env "bash" script which would be tested/used locally as well (like DB operations, etc).

The easiest way to properly read json data in "bash" without injecting PHP would be using "jq", like:
`MYSQL_USER="$(echo $MAGENTO_CLOUD_RELATIONSHIPS | base64 -d | jq -r '.database[0].username')"`

All the Magento Cloud ENVs (Integration/Staging/PROD) has "jq" installed by default, but it doesn't exists locally, forcing us to install it locally (via apt-get) each time when the script should be executed.

### Manual testing scenarios
1. Execute next command from within PHP CLI container (eg "deploy" one)
`echo $MAGENTO_CLOUD_RELATIONSHIPS | base64 -d | jq -r '.database[0].username'`

![image](https://user-images.githubusercontent.com/4457354/231770013-8d9eea36-5d04-446a-a95f-03aa10ac9f8e.png)



### Release notes

Added "[jq](https://stedolan.github.io/jq/tutorial/)" CLI tool to easily read json-encoded ENV variables in PHP CLI containers.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [x] All commits are accompanied by meaningful commit messages
