### PR TITLE
Add FTP ext to PHP 8.2 and 8.3

### DIFF
--- a/images/php/8.2-cli/Dockerfile
+++ b/images/php/8.2-cli/Dockerfile
@@ -29,7 +29,7 @@ ENV MAGENTO_RUN_MODE production
 ENV SENDMAIL_PATH /dev/null
 ENV PHPRC ${MAGENTO_ROOT}/php.ini
 
-ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sodium sysvmsg sysvsem sysvshm xsl zip pcntl
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sodium sysvmsg sysvsem sysvshm xsl zip pcntl ftp
 
 # Configure Node.js version
 RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash
@@ -114,7 +114,8 @@ RUN docker-php-ext-install -j$(nproc) \
   tidy \
   xsl \
   zip \
-  pcntl
+  pcntl \
+  ftp
 
 RUN pecl install -o -f \
   gnupg \

--- a/images/php/8.2-fpm/Dockerfile
+++ b/images/php/8.2-fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV UPLOAD_MAX_FILESIZE 64M
 ENV SENDMAIL_PATH /dev/null
 ENV PHPRC ${MAGENTO_ROOT}/php.ini
 
-ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sodium sysvmsg sysvsem sysvshm xsl zip pcntl
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sodium sysvmsg sysvsem sysvshm xsl zip pcntl ftp
 
 # Install dependencies
 RUN apt-get update \
@@ -89,7 +89,8 @@ RUN docker-php-ext-install -j$(nproc) \
   tidy \
   xsl \
   zip \
-  pcntl
+  pcntl \
+  ftp
 
 RUN pecl install -o -f \
   gnupg \

--- a/images/php/8.3-cli/Dockerfile
+++ b/images/php/8.3-cli/Dockerfile
@@ -29,7 +29,7 @@ ENV MAGENTO_RUN_MODE production
 ENV SENDMAIL_PATH /dev/null
 ENV PHPRC ${MAGENTO_ROOT}/php.ini
 
-ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sodium sysvmsg sysvsem sysvshm xsl zip pcntl
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sodium sysvmsg sysvsem sysvshm xsl zip pcntl ftp
 
 # Configure Node.js version
 RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash
@@ -114,7 +114,8 @@ RUN docker-php-ext-install -j$(nproc) \
   tidy \
   xsl \
   zip \
-  pcntl
+  pcntl \
+  ftp
 
 RUN pecl install -o -f \
   gnupg \

--- a/images/php/8.3-fpm/Dockerfile
+++ b/images/php/8.3-fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV UPLOAD_MAX_FILESIZE 64M
 ENV SENDMAIL_PATH /dev/null
 ENV PHPRC ${MAGENTO_ROOT}/php.ini
 
-ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sodium sysvmsg sysvsem sysvshm xsl zip pcntl
+ENV PHP_EXTENSIONS bcmath bz2 calendar exif gd gettext intl mysqli opcache pdo_mysql redis soap sockets sodium sysvmsg sysvsem sysvshm xsl zip pcntl ftp
 
 # Install dependencies
 RUN apt-get update \
@@ -89,7 +89,8 @@ RUN docker-php-ext-install -j$(nproc) \
   tidy \
   xsl \
   zip \
-  pcntl
+  pcntl \
+  ftp
 
 RUN pecl install -o -f \
   gnupg \


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description

PHP 8.2.15 removed FTP extension, so I'm adding it to the Docker images for PHP 8.2 and 8.3

### Related Pull Requests
<!-- related pull request placeholder -->
1. https://github.com/magento/magento2/pull/39084

### Fixed Issues (if relevant)

1. Fixes https://github.com/magento/magento2/issues/39083

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Try to use CSV import via FTP on PHP 8.2.15 or greater

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [x] All commits are accompanied by meaningful commit messages
