### PR TITLE
Update xdebug version to stable one

### DIFF
--- a/images/php/8.3-fpm/Dockerfile
+++ b/images/php/8.3-fpm/Dockerfile
@@ -99,7 +99,7 @@ RUN pecl install -o -f \
   pcov \
   raphf \
   redis \
-  xdebug-3.3.0 \
+  xdebug-3.3.2 \
   xmlrpc-1.0.0RC3 \
   yaml
 


### PR DESCRIPTION
Fix "Segmentation fault (core dumped)" when using xdebug container by update to stable version

### Description
Update the xdebug versions to fix the `Segmentation fault` when using the PHP command.

### Fixed Issues (if relevant)
1. magento/magento-cloud-docker#369: Php Segmentation fault with xdebug

### Manual testing scenarios
1. `docker exec -it magento2_fpm_xdebug_1 bash`
3. `php -i`
4. `bin/magento`

### Release notes
For user-facing changes, add a meaningful release note. For examples, see [Magento Cloud Docker release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful release notes and documentation
 - [ ] All commits are accompanied by meaningful commit messages
